### PR TITLE
refactor: move list filtering logic from cmd to pkg layer

### DIFF
--- a/cmd/tdh/list.go
+++ b/cmd/tdh/list.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/arthur-debert/tdh/pkg/tdh"
 	"github.com/arthur-debert/tdh/pkg/tdh/display"
-	"github.com/arthur-debert/tdh/pkg/tdh/models"
 	"github.com/spf13/cobra"
 )
 
@@ -20,25 +19,14 @@ var listCmd = &cobra.Command{
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("collection")
 
-		// Call business logic
+		// Call business logic with filtering options
 		result, err := tdh.List(tdh.ListOptions{
 			CollectionPath: collectionPath,
+			ShowDone:       showDone,
+			ShowAll:        showAll,
 		})
 		if err != nil {
 			return err
-		}
-
-		// Filter based on flags
-		if !showAll {
-			var filteredTodos []*models.Todo
-			for _, todo := range result.Todos {
-				if showDone && todo.Status == "done" {
-					filteredTodos = append(filteredTodos, todo)
-				} else if !showDone && todo.Status != "done" {
-					filteredTodos = append(filteredTodos, todo)
-				}
-			}
-			result.Todos = filteredTodos
 		}
 
 		// Render output

--- a/pkg/tdh/commands.go
+++ b/pkg/tdh/commands.go
@@ -285,6 +285,8 @@ func Search(query string, opts SearchOptions) (*SearchResult, error) {
 // ListOptions contains options for listing todos
 type ListOptions struct {
 	CollectionPath string
+	ShowDone       bool
+	ShowAll        bool
 }
 
 // ListResult contains the result of listing todos
@@ -294,7 +296,7 @@ type ListResult struct {
 	DoneCount  int
 }
 
-// List returns all todos in the collection
+// List returns todos from the collection with optional filtering
 func List(opts ListOptions) (*ListResult, error) {
 	s := store.NewStore(opts.CollectionPath)
 	collection, err := s.Load()
@@ -302,15 +304,31 @@ func List(opts ListOptions) (*ListResult, error) {
 		return nil, err
 	}
 
+	todos := collection.Todos
 	doneCount := 0
+
+	// Count done todos
 	for _, todo := range collection.Todos {
 		if todo.Status == "done" {
 			doneCount++
 		}
 	}
 
+	// Apply filtering if not showing all
+	if !opts.ShowAll {
+		var filteredTodos []*models.Todo
+		for _, todo := range collection.Todos {
+			if opts.ShowDone && todo.Status == "done" {
+				filteredTodos = append(filteredTodos, todo)
+			} else if !opts.ShowDone && todo.Status != "done" {
+				filteredTodos = append(filteredTodos, todo)
+			}
+		}
+		todos = filteredTodos
+	}
+
 	return &ListResult{
-		Todos:      collection.Todos,
+		Todos:      todos,
 		TotalCount: len(collection.Todos),
 		DoneCount:  doneCount,
 	}, nil


### PR DESCRIPTION
## Summary
- Moved filtering logic from `cmd/tdh/list.go` to `pkg/tdh/commands.go` to maintain clean architecture
- Added `ShowDone` and `ShowAll` fields to `ListOptions` struct for filtering control
- Updated `List` function in pkg layer to handle filtering based on options

## Changes
- **cmd/tdh/list.go**: Removed filtering logic, now passes flags directly to pkg API
- **pkg/tdh/commands.go**: Enhanced `ListOptions` struct and `List` function to handle filtering
- Removed unnecessary `models` import from cmd layer

## Architecture Benefits
This change ensures the cmd layer only handles CLI parsing, validation, and output formatting, while all business logic remains in the pkg layer. This follows the project's strict cmd/pkg architecture pattern.

## Test Results
- ✅ All existing tests pass
- ✅ Linting clean (golangci-lint)
- ✅ Manual testing confirms filtering works correctly:
  - `tdh list` - shows only pending todos
  - `tdh list --done` - shows only completed todos
  - `tdh list --all` - shows all todos

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)