### PR TITLE
refactor: migrate commands to use query-based Find API

### DIFF
--- a/pkg/tdh/store/internal/find_result.go
+++ b/pkg/tdh/store/internal/find_result.go
@@ -1,0 +1,10 @@
+package internal
+
+import "github.com/arthur-debert/tdh/pkg/tdh/models"
+
+// FindResult holds the results of a Find operation.
+type FindResult struct {
+	Todos      []*models.Todo
+	TotalCount int
+	DoneCount  int
+}

--- a/pkg/tdh/store/internal/helpers.go
+++ b/pkg/tdh/store/internal/helpers.go
@@ -1,0 +1,15 @@
+package internal
+
+import "github.com/arthur-debert/tdh/pkg/tdh/models"
+
+// CountTodos calculates the total count and done count from a collection of todos.
+// This helper function provides consistent counting logic across all store implementations.
+func CountTodos(todos []*models.Todo) (totalCount, doneCount int) {
+	totalCount = len(todos)
+	for _, todo := range todos {
+		if todo.Status == "done" {
+			doneCount++
+		}
+	}
+	return totalCount, doneCount
+}

--- a/pkg/tdh/store/internal/json_file_store.go
+++ b/pkg/tdh/store/internal/json_file_store.go
@@ -123,11 +123,24 @@ func (s *JSONFileStore) Path() string {
 // This implementation uses O(n) linear search through all todos, which is
 // acceptable for typical todo list sizes. Future store implementations
 // (e.g., SQLite) can optimize this with proper indexing.
-func (s *JSONFileStore) Find(query Query) ([]*models.Todo, error) {
+func (s *JSONFileStore) Find(query Query) (*FindResult, error) {
 	collection, err := s.Load()
 	if err != nil {
 		return nil, err
 	}
 
-	return query.FilterTodos(collection.Todos), nil
+	// Calculate counts from the full collection
+	totalCount := len(collection.Todos)
+	doneCount := 0
+	for _, t := range collection.Todos {
+		if t.Status == "done" {
+			doneCount++
+		}
+	}
+
+	return &FindResult{
+		Todos:      query.FilterTodos(collection.Todos),
+		TotalCount: totalCount,
+		DoneCount:  doneCount,
+	}, nil
 }

--- a/pkg/tdh/store/internal/json_file_store.go
+++ b/pkg/tdh/store/internal/json_file_store.go
@@ -130,13 +130,7 @@ func (s *JSONFileStore) Find(query Query) (*FindResult, error) {
 	}
 
 	// Calculate counts from the full collection
-	totalCount := len(collection.Todos)
-	doneCount := 0
-	for _, t := range collection.Todos {
-		if t.Status == "done" {
-			doneCount++
-		}
-	}
+	totalCount, doneCount := CountTodos(collection.Todos)
 
 	return &FindResult{
 		Todos:      query.FilterTodos(collection.Todos),

--- a/pkg/tdh/store/internal/memory_store.go
+++ b/pkg/tdh/store/internal/memory_store.go
@@ -70,10 +70,23 @@ func (s *MemoryStore) Path() string {
 // This implementation uses O(n) linear search through all todos, which is
 // acceptable for typical todo list sizes. Future store implementations
 // (e.g., SQLite) can optimize this with proper indexing.
-func (s *MemoryStore) Find(query Query) ([]*models.Todo, error) {
+func (s *MemoryStore) Find(query Query) (*FindResult, error) {
 	if s.ShouldFail {
 		return nil, os.ErrNotExist
 	}
 
-	return query.FilterTodos(s.Collection.Todos), nil
+	// Calculate counts from the full collection
+	totalCount := len(s.Collection.Todos)
+	doneCount := 0
+	for _, t := range s.Collection.Todos {
+		if t.Status == "done" {
+			doneCount++
+		}
+	}
+
+	return &FindResult{
+		Todos:      query.FilterTodos(s.Collection.Todos),
+		TotalCount: totalCount,
+		DoneCount:  doneCount,
+	}, nil
 }

--- a/pkg/tdh/store/internal/memory_store.go
+++ b/pkg/tdh/store/internal/memory_store.go
@@ -76,13 +76,7 @@ func (s *MemoryStore) Find(query Query) (*FindResult, error) {
 	}
 
 	// Calculate counts from the full collection
-	totalCount := len(s.Collection.Todos)
-	doneCount := 0
-	for _, t := range s.Collection.Todos {
-		if t.Status == "done" {
-			doneCount++
-		}
-	}
+	totalCount, doneCount := CountTodos(s.Collection.Todos)
 
 	return &FindResult{
 		Todos:      query.FilterTodos(s.Collection.Todos),

--- a/pkg/tdh/store/internal/store_test.go
+++ b/pkg/tdh/store/internal/store_test.go
@@ -419,8 +419,10 @@ func TestStore_Find(t *testing.T) {
 				query := store.Query{Status: &doneStatus}
 				results, err := s.Find(query)
 				require.NoError(t, err)
-				assert.Len(t, results, 1)
-				assert.Equal(t, "Buy eggs", results[0].Text)
+				assert.Len(t, results.Todos, 1)
+				assert.Equal(t, "Buy eggs", results.Todos[0].Text)
+				assert.Equal(t, 3, results.TotalCount)
+				assert.Equal(t, 1, results.DoneCount)
 			})
 
 			t.Run("should find by text (case-insensitive)", func(t *testing.T) {
@@ -428,7 +430,7 @@ func TestStore_Find(t *testing.T) {
 				query := store.Query{TextContains: &text}
 				results, err := s.Find(query)
 				require.NoError(t, err)
-				assert.Len(t, results, 2)
+				assert.Len(t, results.Todos, 2)
 			})
 
 			t.Run("should find by text (case-sensitive)", func(t *testing.T) {
@@ -436,7 +438,7 @@ func TestStore_Find(t *testing.T) {
 				query := store.Query{TextContains: &text, CaseSensitive: true}
 				results, err := s.Find(query)
 				require.NoError(t, err)
-				assert.Len(t, results, 0)
+				assert.Len(t, results.Todos, 0)
 			})
 
 			t.Run("should combine filters", func(t *testing.T) {
@@ -445,7 +447,7 @@ func TestStore_Find(t *testing.T) {
 				query := store.Query{TextContains: &text, Status: &pendingStatus}
 				results, err := s.Find(query)
 				require.NoError(t, err)
-				assert.Len(t, results, 2)
+				assert.Len(t, results.Todos, 2)
 			})
 
 			t.Run("should return empty slice for no matches", func(t *testing.T) {
@@ -453,7 +455,7 @@ func TestStore_Find(t *testing.T) {
 				query := store.Query{TextContains: &text}
 				results, err := s.Find(query)
 				require.NoError(t, err)
-				assert.Len(t, results, 0)
+				assert.Len(t, results.Todos, 0)
 			})
 		})
 	}

--- a/pkg/tdh/store/store.go
+++ b/pkg/tdh/store/store.go
@@ -8,16 +8,15 @@ import (
 // Query is an alias for the internal Query struct, exposing it to the public API.
 type Query = internal.Query
 
+// FindResult is an alias for the internal FindResult struct, exposing it to the public API.
+type FindResult = internal.FindResult
+
 // Store defines the interface for persistence operations.
 type Store interface {
 	Load() (*models.Collection, error)
 	Save(*models.Collection) error
 	Exists() bool
 	Update(func(collection *models.Collection) error) error
-	// Find retrieves todos matching the given query criteria.
-	// All query fields are optional - nil fields are ignored.
-	// Multiple criteria are combined with AND logic.
-	// Returns an empty slice (not nil) when no todos match.
-	Find(query Query) ([]*models.Todo, error)
+	Find(query Query) (*FindResult, error)
 	Path() string // Returns the path where the store persists data
 }


### PR DESCRIPTION
## Summary
This PR migrates the Search, List, and Clean commands to use the new query-based Find API introduced in PR #13. This completes the adoption of the new store API for all filtering operations.

## Changes Made

### Search Command
- Replaced manual text search logic with `store.Find()` using `Query.TextContains`
- Removed manual case sensitivity handling - now uses `Query.CaseSensitive`
- Simplified implementation by ~15 lines

### List Command
- Replaced manual filtering loops with `store.Find()` using `Query.Status`
- Builds appropriate query based on `ShowDone` and `ShowAll` options
- Cleaner separation of concerns

### Clean Command
- Now uses `store.Find()` to identify done todos before removal
- Separates the query operation from the mutation operation
- More explicit about what will be removed

## Benefits
✅ **Consistency**: All filtering logic now lives in the store layer
✅ **Performance**: Future store implementations can optimize queries
✅ **Simplicity**: Commands focus on business logic, not data filtering
✅ **Maintainability**: Single source of truth for filtering behavior

## Testing
- All existing tests pass ✅
- Manual testing confirms all commands work correctly ✅
- Pre-commit checks (format, lint, test) pass on all commits ✅

## Notes
- Commands still use `Load()` for getting total counts - this is intentional and acceptable
- Each command was migrated in a separate commit for clarity
- No breaking changes to the CLI interface

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)