### PR TITLE
test: port existing tests to use testutil package

### DIFF
--- a/pkg/tdh/commands/add/add_test.go
+++ b/pkg/tdh/commands/add/add_test.go
@@ -1,43 +1,30 @@
 package add_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/arthur-debert/tdh/pkg/tdh"
-	"github.com/arthur-debert/tdh/pkg/tdh/store"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// setupTestStore creates a temporary directory and a JSONFileStore for testing.
-func setupTestStore(t *testing.T) (string, func()) {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "tdh-cmd-test")
-	require.NoError(t, err)
-	dbPath := filepath.Join(dir, "test.json")
-	return dbPath, func() {
-		err := os.RemoveAll(dir)
-		require.NoError(t, err)
-	}
-}
-
 func TestAddCommand(t *testing.T) {
-	dbPath, cleanup := setupTestStore(t)
-	defer cleanup()
+	// Use testutil to create a clean store
+	store := testutil.CreatePopulatedStore(t) // Empty store
 
-	opts := tdh.AddOptions{CollectionPath: dbPath}
+	opts := tdh.AddOptions{CollectionPath: store.Path()}
 	result, err := tdh.Add("My first todo", opts)
 
-	require.NoError(t, err)
+	// Use testutil assertions
+	testutil.AssertNoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "My first todo", result.Todo.Text)
 	assert.Equal(t, int64(1), result.Todo.ID)
 
-	// Verify it was saved
-	s := store.NewStore(dbPath)
-	collection, err := s.Load()
-	require.NoError(t, err)
-	assert.Len(t, collection.Todos, 1)
+	// Verify it was saved using testutil
+	collection, err := store.Load()
+	testutil.AssertNoError(t, err)
+
+	testutil.AssertCollectionSize(t, collection, 1)
+	testutil.AssertTodoInList(t, collection.Todos, "My first todo")
 }

--- a/pkg/tdh/commands/toggle/toggle_test.go
+++ b/pkg/tdh/commands/toggle/toggle_test.go
@@ -1,57 +1,34 @@
 package toggle_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/arthur-debert/tdh/pkg/tdh"
 	"github.com/arthur-debert/tdh/pkg/tdh/models"
-	"github.com/arthur-debert/tdh/pkg/tdh/store"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-// setupTestStore creates a temporary directory and a JSONFileStore for testing.
-func setupTestStore(t *testing.T) (string, func()) {
-	t.Helper()
-	dir, err := os.MkdirTemp("", "tdh-cmd-test")
-	require.NoError(t, err)
-	dbPath := filepath.Join(dir, "test.json")
-	return dbPath, func() {
-		err := os.RemoveAll(dir)
-		require.NoError(t, err)
-	}
-}
-
 func TestToggleCommand(t *testing.T) {
-	dbPath, cleanup := setupTestStore(t)
-	defer cleanup()
+	// Create a store with a pending todo
+	store := testutil.CreatePopulatedStore(t, "Todo to toggle")
 
-	// Add a todo first
-	addOpts := tdh.AddOptions{CollectionPath: dbPath}
-	addResult, err := tdh.Add("Todo to toggle", addOpts)
-	require.NoError(t, err)
+	// Get the todo ID (it will be 1 since it's the first todo)
+	collection, _ := store.Load()
+	todoID := collection.Todos[0].ID
 
-	toggleOpts := tdh.ToggleOptions{CollectionPath: dbPath}
-	toggleResult, err := tdh.Toggle(int(addResult.Todo.ID), toggleOpts)
+	// Toggle the todo
+	toggleOpts := tdh.ToggleOptions{CollectionPath: store.Path()}
+	toggleResult, err := tdh.Toggle(int(todoID), toggleOpts)
 
-	require.NoError(t, err)
+	testutil.AssertNoError(t, err)
 	assert.Equal(t, string(models.StatusDone), toggleResult.NewStatus)
 
-	// Verify it was saved
-	s := store.NewStore(dbPath)
-	collection, err := s.Load()
-	require.NoError(t, err)
+	// Verify it was saved using testutil
+	collection, err = store.Load()
+	testutil.AssertNoError(t, err)
 
-	// Find the todo by ID
-	var found *models.Todo
-	for _, todo := range collection.Todos {
-		if todo.ID == addResult.Todo.ID {
-			found = todo
-			break
-		}
-	}
-	require.NotNil(t, found, "todo not found")
-	assert.Equal(t, models.StatusDone, found.Status)
+	// Use testutil to find and verify the todo
+	todo := testutil.AssertTodoByID(t, collection.Todos, todoID)
+	testutil.AssertTodoHasStatus(t, todo, models.StatusDone)
 }


### PR DESCRIPTION
## Summary
This PR completes Phase 2 of the test suite restructuring by porting all existing command tests to use the new testutil package created in #25.

## Changes Made

### Tests Ported
1. **`pkg/tdh/commands/add/add_test.go`**
   - Replaced manual test store setup with `testutil.CreatePopulatedStore`
   - Used testutil assertions: `AssertNoError`, `AssertCollectionSize`, `AssertTodoInList`
   - Removed duplicate `setupTestStore` function

2. **`pkg/tdh/commands/toggle/toggle_test.go`**
   - Used `testutil.CreatePopulatedStore` for initial setup
   - Used `testutil.AssertTodoByID` to find todos
   - Used `testutil.AssertTodoHasStatus` for status verification
   - Much cleaner test flow

3. **`pkg/tdh/commands/clean/clean_test.go`**
   - Used `testutil.CreateStoreWithSpecs` to create mixed todo states
   - Used `testutil.AssertTodoNotInList` to verify removal
   - Eliminated manual todo creation and toggling

### Tests Not Modified
- **Store tests** (`factory_test.go`, `store/internal/store_test.go`) - These test low-level store functionality and don't benefit from testutil as per the guidelines

### Commands Without Tests
The following commands don't have tests yet, so there was nothing to port:
- init
- list
- modify
- reorder
- search

## Benefits
- **Reduced duplication** - No more `setupTestStore` in each test file
- **Improved readability** - Descriptive assertions make tests self-documenting
- **Easier setup** - Especially for tests needing specific todo states
- **Consistency** - All command tests now follow the same patterns

## Test Results
All tests pass:
```
✓  pkg/tdh/commands/add
✓  pkg/tdh/commands/toggle
✓  pkg/tdh/commands/clean
```

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)