### PR TITLE
Phase 3: Add guidance tests for all commands

### DIFF
--- a/pkg/tdh/commands/init/init_test.go
+++ b/pkg/tdh/commands/init/init_test.go
@@ -1,0 +1,79 @@
+package init_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cmdinit "github.com/arthur-debert/tdh/pkg/tdh/commands/init"
+	"github.com/arthur-debert/tdh/pkg/tdh/store"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCommand(t *testing.T) {
+	t.Run("creates new todo file when none exists", func(t *testing.T) {
+		// Setup temp directory
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "todos.json")
+
+		// Execute init command
+		opts := cmdinit.Options{DBPath: dbPath}
+		result, err := cmdinit.Execute(opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		assert.True(t, result.Created)
+		assert.Equal(t, dbPath, result.DBPath)
+		assert.Contains(t, result.Message, "Initialized empty tdh collection")
+
+		// Verify file was created with empty collection
+		s := store.NewStore(dbPath)
+		collection, err := s.Load()
+		testutil.AssertNoError(t, err)
+		testutil.AssertCollectionSize(t, collection, 0)
+	})
+
+	t.Run("reinitializes when file already exists", func(t *testing.T) {
+		// Create a populated store using testutil
+		s := testutil.CreatePopulatedStore(t, "Existing todo 1", "Existing todo 2")
+		dbPath := s.Path()
+
+		// Execute init command on existing file
+		opts := cmdinit.Options{DBPath: dbPath}
+		result, err := cmdinit.Execute(opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		assert.False(t, result.Created)
+		assert.Equal(t, dbPath, result.DBPath)
+		assert.Contains(t, result.Message, "Reinitialized existing tdh collection")
+
+		// Verify existing todos are preserved
+		collection, err := s.Load()
+		testutil.AssertNoError(t, err)
+		testutil.AssertCollectionSize(t, collection, 2)
+		testutil.AssertTodoInList(t, collection.Todos, "Existing todo 1")
+		testutil.AssertTodoInList(t, collection.Todos, "Existing todo 2")
+	})
+
+	t.Run("handles write errors gracefully", func(t *testing.T) {
+		// Create a directory with no write permissions
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "readonly", "todos.json")
+
+		// Create parent directory with read-only permissions
+		err := os.Mkdir(filepath.Dir(dbPath), 0555)
+		require.NoError(t, err)
+
+		// Execute init command
+		opts := cmdinit.Options{DBPath: dbPath}
+		result, err := cmdinit.Execute(opts)
+
+		// Verify error handling
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to create store file")
+	})
+}

--- a/pkg/tdh/commands/list/list_test.go
+++ b/pkg/tdh/commands/list/list_test.go
@@ -1,0 +1,146 @@
+package list_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/list"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListCommand(t *testing.T) {
+	t.Run("lists only pending todos by default", func(t *testing.T) {
+		// Create store with mixed todo states using testutil
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending task 1", Status: models.StatusPending},
+			{Text: "Done task 1", Status: models.StatusDone},
+			{Text: "Pending task 2", Status: models.StatusPending},
+			{Text: "Done task 2", Status: models.StatusDone},
+		})
+
+		// Execute list command with default options
+		opts := list.Options{
+			CollectionPath: store.Path(),
+			ShowDone:       false,
+			ShowAll:        false,
+		}
+		result, err := list.Execute(opts)
+
+		// Verify using testutil assertions
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 2, len(result.Todos))
+		assert.Equal(t, 4, result.TotalCount)
+		assert.Equal(t, 2, result.DoneCount)
+
+		// Verify only pending todos are returned
+		for _, todo := range result.Todos {
+			testutil.AssertTodoHasStatus(t, todo, models.StatusPending)
+		}
+		testutil.AssertTodoInList(t, result.Todos, "Pending task 1")
+		testutil.AssertTodoInList(t, result.Todos, "Pending task 2")
+	})
+
+	t.Run("lists only done todos with ShowDone flag", func(t *testing.T) {
+		// Create store with mixed todo states
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending task", Status: models.StatusPending},
+			{Text: "Done task 1", Status: models.StatusDone},
+			{Text: "Done task 2", Status: models.StatusDone},
+		})
+
+		// Execute list command with ShowDone flag
+		opts := list.Options{
+			CollectionPath: store.Path(),
+			ShowDone:       true,
+			ShowAll:        false,
+		}
+		result, err := list.Execute(opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 2, len(result.Todos))
+		assert.Equal(t, 3, result.TotalCount)
+		assert.Equal(t, 2, result.DoneCount)
+
+		// Verify only done todos are returned
+		for _, todo := range result.Todos {
+			testutil.AssertTodoHasStatus(t, todo, models.StatusDone)
+		}
+		testutil.AssertTodoInList(t, result.Todos, "Done task 1")
+		testutil.AssertTodoInList(t, result.Todos, "Done task 2")
+	})
+
+	t.Run("lists all todos with ShowAll flag", func(t *testing.T) {
+		// Create store with mixed todo states
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending task 1", Status: models.StatusPending},
+			{Text: "Done task 1", Status: models.StatusDone},
+			{Text: "Pending task 2", Status: models.StatusPending},
+			{Text: "Done task 2", Status: models.StatusDone},
+		})
+
+		// Execute list command with ShowAll flag
+		opts := list.Options{
+			CollectionPath: store.Path(),
+			ShowDone:       false, // This should be ignored when ShowAll is true
+			ShowAll:        true,
+		}
+		result, err := list.Execute(opts)
+
+		// Verify all todos are returned
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 4, len(result.Todos))
+		assert.Equal(t, 4, result.TotalCount)
+		assert.Equal(t, 2, result.DoneCount)
+
+		// Verify all todos are present
+		testutil.AssertTodoInList(t, result.Todos, "Pending task 1")
+		testutil.AssertTodoInList(t, result.Todos, "Done task 1")
+		testutil.AssertTodoInList(t, result.Todos, "Pending task 2")
+		testutil.AssertTodoInList(t, result.Todos, "Done task 2")
+	})
+
+	t.Run("handles empty collection gracefully", func(t *testing.T) {
+		// Create empty store
+		store := testutil.CreatePopulatedStore(t) // Empty store
+
+		// Execute list command
+		opts := list.Options{
+			CollectionPath: store.Path(),
+			ShowDone:       false,
+			ShowAll:        false,
+		}
+		result, err := list.Execute(opts)
+
+		// Verify empty results
+		testutil.AssertNoError(t, err)
+		assert.Empty(t, result.Todos)
+		assert.Equal(t, 0, result.TotalCount)
+		assert.Equal(t, 0, result.DoneCount)
+	})
+
+	t.Run("returns counts even when filtering", func(t *testing.T) {
+		// Create store with specific todo distribution
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending 1", Status: models.StatusPending},
+			{Text: "Pending 2", Status: models.StatusPending},
+			{Text: "Pending 3", Status: models.StatusPending},
+			{Text: "Done 1", Status: models.StatusDone},
+			{Text: "Done 2", Status: models.StatusDone},
+		})
+
+		// Test with pending filter
+		opts := list.Options{
+			CollectionPath: store.Path(),
+			ShowDone:       false,
+			ShowAll:        false,
+		}
+		result, err := list.Execute(opts)
+
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 3, len(result.Todos)) // Only pending todos returned
+		assert.Equal(t, 5, result.TotalCount) // But total count includes all
+		assert.Equal(t, 2, result.DoneCount)  // And done count is accurate
+	})
+}

--- a/pkg/tdh/commands/modify/modify_test.go
+++ b/pkg/tdh/commands/modify/modify_test.go
@@ -1,0 +1,140 @@
+package modify_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/modify"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModifyCommand(t *testing.T) {
+	t.Run("successfully modifies todo text", func(t *testing.T) {
+		// Create store with test todos using testutil
+		store := testutil.CreatePopulatedStore(t, "Original todo text", "Another todo")
+
+		// Get the first todo's ID
+		collection, _ := store.Load()
+		todoID := collection.Todos[0].ID
+
+		// Execute modify command
+		opts := modify.Options{CollectionPath: store.Path()}
+		result, err := modify.Execute(int(todoID), "Modified todo text", opts)
+
+		// Verify result
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Original todo text", result.OldText)
+		assert.Equal(t, "Modified todo text", result.NewText)
+		assert.Equal(t, "Modified todo text", result.Todo.Text)
+
+		// Verify persistence using testutil
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		todo := testutil.AssertTodoByID(t, collection.Todos, todoID)
+		assert.Equal(t, "Modified todo text", todo.Text)
+
+		// Ensure other todos are unchanged
+		testutil.AssertTodoInList(t, collection.Todos, "Another todo")
+	})
+
+	t.Run("preserves todo status when modifying", func(t *testing.T) {
+		// Create store with a done todo
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Completed task", Status: models.StatusDone},
+		})
+
+		// Get the todo's ID
+		collection, _ := store.Load()
+		todoID := collection.Todos[0].ID
+
+		// Modify the todo
+		opts := modify.Options{CollectionPath: store.Path()}
+		result, err := modify.Execute(int(todoID), "Completed task (updated)", opts)
+
+		// Verify status is preserved
+		testutil.AssertNoError(t, err)
+		testutil.AssertTodoHasStatus(t, result.Todo, models.StatusDone)
+
+		// Verify in persistence
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		todo := testutil.AssertTodoByID(t, collection.Todos, todoID)
+		testutil.AssertTodoHasStatus(t, todo, models.StatusDone)
+	})
+
+	t.Run("returns error for non-existent todo", func(t *testing.T) {
+		// Create store with one todo
+		store := testutil.CreatePopulatedStore(t, "Existing todo")
+
+		// Try to modify non-existent todo
+		opts := modify.Options{CollectionPath: store.Path()}
+		result, err := modify.Execute(999, "New text", opts)
+
+		// Verify error
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "todo not found")
+
+		// Verify no changes were made
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		testutil.AssertCollectionSize(t, collection, 1)
+		testutil.AssertTodoInList(t, collection.Todos, "Existing todo")
+	})
+
+	t.Run("returns error for empty new text", func(t *testing.T) {
+		// Create store with test todo
+		store := testutil.CreatePopulatedStore(t, "Original text")
+
+		// Get the todo's ID
+		collection, _ := store.Load()
+		todoID := collection.Todos[0].ID
+
+		// Try to modify with empty text
+		opts := modify.Options{CollectionPath: store.Path()}
+		result, err := modify.Execute(int(todoID), "", opts)
+
+		// Verify error
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "new todo text cannot be empty")
+
+		// Verify no changes were made
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		todo := testutil.AssertTodoByID(t, collection.Todos, todoID)
+		assert.Equal(t, "Original text", todo.Text)
+	})
+
+	t.Run("handles modification of multiple todos correctly", func(t *testing.T) {
+		// Create store with multiple todos
+		store := testutil.CreatePopulatedStore(t,
+			"First todo",
+			"Second todo",
+			"Third todo",
+		)
+
+		// Get the second todo's ID
+		collection, _ := store.Load()
+		secondTodoID := collection.Todos[1].ID
+
+		// Modify only the second todo
+		opts := modify.Options{CollectionPath: store.Path()}
+		result, err := modify.Execute(int(secondTodoID), "Second todo (modified)", opts)
+
+		// Verify correct todo was modified
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Second todo", result.OldText)
+		assert.Equal(t, "Second todo (modified)", result.NewText)
+
+		// Verify persistence and other todos unchanged
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		testutil.AssertCollectionSize(t, collection, 3)
+		testutil.AssertTodoInList(t, collection.Todos, "First todo")
+		testutil.AssertTodoInList(t, collection.Todos, "Second todo (modified)")
+		testutil.AssertTodoInList(t, collection.Todos, "Third todo")
+	})
+}

--- a/pkg/tdh/commands/reorder/reorder_test.go
+++ b/pkg/tdh/commands/reorder/reorder_test.go
@@ -1,0 +1,184 @@
+package reorder_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/reorder"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReorderCommand(t *testing.T) {
+	t.Run("successfully swaps two todos", func(t *testing.T) {
+		// Create store with multiple todos using testutil
+		store := testutil.CreatePopulatedStore(t,
+			"First todo",
+			"Second todo",
+			"Third todo",
+			"Fourth todo",
+		)
+
+		// Get the collection to verify initial state
+		collection, _ := store.Load()
+		firstID := collection.Todos[0].ID
+		thirdID := collection.Todos[2].ID
+
+		// Execute reorder command to swap first and third
+		opts := reorder.Options{CollectionPath: store.Path()}
+		result, err := reorder.Execute(int(firstID), int(thirdID), opts)
+
+		// Verify result
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.TodoA)
+		assert.NotNil(t, result.TodoB)
+
+		// Verify the swap in persistence
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+
+		// After swap, the IDs are also swapped, so:
+		// Position 0 should have third todo with first ID
+		// Position 2 should have first todo with third ID
+		assert.Equal(t, firstID, collection.Todos[0].ID)
+		assert.Equal(t, "Third todo", collection.Todos[0].Text)
+		assert.Equal(t, thirdID, collection.Todos[2].ID)
+		assert.Equal(t, "First todo", collection.Todos[2].Text)
+
+		// Other todos should remain unchanged
+		assert.Equal(t, "Second todo", collection.Todos[1].Text)
+		assert.Equal(t, "Fourth todo", collection.Todos[3].Text)
+	})
+
+	t.Run("swaps adjacent todos correctly", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t,
+			"Todo A",
+			"Todo B",
+			"Todo C",
+		)
+
+		// Get IDs
+		collection, _ := store.Load()
+		idA := collection.Todos[0].ID
+		idB := collection.Todos[1].ID
+
+		// Swap adjacent todos
+		opts := reorder.Options{CollectionPath: store.Path()}
+		result, err := reorder.Execute(int(idA), int(idB), opts)
+
+		// Verify
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+
+		// Check persistence
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+
+		// After swap: B, A, C (with swapped IDs)
+		assert.Equal(t, idA, collection.Todos[0].ID)
+		assert.Equal(t, "Todo B", collection.Todos[0].Text)
+		assert.Equal(t, idB, collection.Todos[1].ID)
+		assert.Equal(t, "Todo A", collection.Todos[1].Text)
+		assert.Equal(t, "Todo C", collection.Todos[2].Text)
+	})
+
+	t.Run("preserves todo status when reordering", func(t *testing.T) {
+		// Create store with mixed todo states
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending todo", Status: models.StatusPending},
+			{Text: "Done todo", Status: models.StatusDone},
+			{Text: "Another pending", Status: models.StatusPending},
+		})
+
+		// Get IDs
+		collection, _ := store.Load()
+		pendingID := collection.Todos[0].ID
+		doneID := collection.Todos[1].ID
+
+		// Swap pending and done todos
+		opts := reorder.Options{CollectionPath: store.Path()}
+		_, err := reorder.Execute(int(pendingID), int(doneID), opts)
+
+		// Verify status preservation
+		testutil.AssertNoError(t, err)
+
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+
+		// First position now has done todo
+		testutil.AssertTodoHasStatus(t, collection.Todos[0], models.StatusDone)
+		assert.Equal(t, "Done todo", collection.Todos[0].Text)
+
+		// Second position now has pending todo
+		testutil.AssertTodoHasStatus(t, collection.Todos[1], models.StatusPending)
+		assert.Equal(t, "Pending todo", collection.Todos[1].Text)
+	})
+
+	t.Run("returns error when first todo not found", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t, "Todo 1", "Todo 2")
+
+		// Get valid ID
+		collection, _ := store.Load()
+		validID := collection.Todos[0].ID
+
+		// Try to reorder with non-existent ID
+		opts := reorder.Options{CollectionPath: store.Path()}
+		result, err := reorder.Execute(999, int(validID), opts)
+
+		// Verify error
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "one or both todos not found")
+
+		// Verify no changes were made
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Todo 1", collection.Todos[0].Text)
+		assert.Equal(t, "Todo 2", collection.Todos[1].Text)
+	})
+
+	t.Run("returns error when second todo not found", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t, "Todo 1", "Todo 2")
+
+		// Get valid ID
+		collection, _ := store.Load()
+		validID := collection.Todos[0].ID
+
+		// Try to reorder with non-existent ID
+		opts := reorder.Options{CollectionPath: store.Path()}
+		result, err := reorder.Execute(int(validID), 999, opts)
+
+		// Verify error
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "one or both todos not found")
+	})
+
+	t.Run("handles reordering same todo gracefully", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t, "Todo 1", "Todo 2", "Todo 3")
+
+		// Get ID
+		collection, _ := store.Load()
+		todoID := collection.Todos[1].ID
+
+		// Try to swap todo with itself
+		opts := reorder.Options{CollectionPath: store.Path()}
+		result, err := reorder.Execute(int(todoID), int(todoID), opts)
+
+		// Should succeed (no-op)
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+
+		// Verify nothing changed
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Todo 1", collection.Todos[0].Text)
+		assert.Equal(t, "Todo 2", collection.Todos[1].Text)
+		assert.Equal(t, "Todo 3", collection.Todos[2].Text)
+	})
+}

--- a/pkg/tdh/commands/search/search_test.go
+++ b/pkg/tdh/commands/search/search_test.go
@@ -1,0 +1,208 @@
+package search_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/search"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchCommand(t *testing.T) {
+	t.Run("finds todos with case-insensitive search by default", func(t *testing.T) {
+		// Create store with various todos using testutil
+		store := testutil.CreatePopulatedStore(t,
+			"Buy milk from store",
+			"Call Mike about project",
+			"MILK the cows",
+			"Send email to team",
+			"Review milestone report",
+		)
+
+		// Execute search for "milk"
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+		result, err := search.Execute("milk", opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "milk", result.Query)
+		assert.Equal(t, 2, len(result.MatchedTodos))
+		assert.Equal(t, 5, result.TotalCount)
+
+		// Verify matched todos using testutil
+		var matchedTexts []string
+		for _, todo := range result.MatchedTodos {
+			matchedTexts = append(matchedTexts, todo.Text)
+		}
+		assert.Contains(t, matchedTexts, "Buy milk from store")
+		assert.Contains(t, matchedTexts, "MILK the cows")
+	})
+
+	t.Run("performs case-sensitive search when enabled", func(t *testing.T) {
+		// Create store with case variations
+		store := testutil.CreatePopulatedStore(t,
+			"TODO: implement feature",
+			"todo: fix bug",
+			"ToDo: review PR",
+			"Need to do something",
+		)
+
+		// Execute case-sensitive search
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  true,
+		}
+		result, err := search.Execute("todo", opts)
+
+		// Verify only exact case match
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 1, len(result.MatchedTodos))
+		assert.Equal(t, "todo: fix bug", result.MatchedTodos[0].Text)
+		assert.Equal(t, 4, result.TotalCount)
+	})
+
+	t.Run("searches across both pending and done todos", func(t *testing.T) {
+		// Create store with mixed status todos using testutil
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Pending: buy coffee", Status: models.StatusPending},
+			{Text: "Done: bought coffee maker", Status: models.StatusDone},
+			{Text: "Pending: meeting at coffee shop", Status: models.StatusPending},
+			{Text: "Done: cleaned coffee pot", Status: models.StatusDone},
+			{Text: "Pending: order tea", Status: models.StatusPending},
+		})
+
+		// Search for "coffee"
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+		result, err := search.Execute("coffee", opts)
+
+		// Verify results include both statuses
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 4, len(result.MatchedTodos))
+		assert.Equal(t, 5, result.TotalCount)
+
+		// Count by status
+		pendingCount := 0
+		doneCount := 0
+		for _, todo := range result.MatchedTodos {
+			switch todo.Status {
+			case models.StatusPending:
+				pendingCount++
+			case models.StatusDone:
+				doneCount++
+			}
+		}
+		assert.Equal(t, 2, pendingCount)
+		assert.Equal(t, 2, doneCount)
+	})
+
+	t.Run("handles partial word matches", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t,
+			"Implement authentication",
+			"Add author field",
+			"Authorize user access",
+			"Create bibliography",
+		)
+
+		// Search for "auth"
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+		result, err := search.Execute("auth", opts)
+
+		// Verify partial matches
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, 3, len(result.MatchedTodos))
+
+		// Verify specific matches
+		var matchedTexts []string
+		for _, todo := range result.MatchedTodos {
+			matchedTexts = append(matchedTexts, todo.Text)
+		}
+		assert.Contains(t, matchedTexts, "Implement authentication")
+		assert.Contains(t, matchedTexts, "Add author field")
+		assert.Contains(t, matchedTexts, "Authorize user access")
+		assert.NotContains(t, matchedTexts, "Create bibliography")
+	})
+
+	t.Run("returns empty results for no matches", func(t *testing.T) {
+		// Create store with todos
+		store := testutil.CreatePopulatedStore(t,
+			"First todo",
+			"Second todo",
+			"Third todo",
+		)
+
+		// Search for non-existent text
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+		result, err := search.Execute("xyz", opts)
+
+		// Verify empty results
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "xyz", result.Query)
+		assert.Empty(t, result.MatchedTodos)
+		assert.Equal(t, 3, result.TotalCount) // Total count still shows all todos
+	})
+
+	t.Run("returns error for empty query", func(t *testing.T) {
+		// Create store
+		store := testutil.CreatePopulatedStore(t, "Some todo")
+
+		// Try empty search
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+		result, err := search.Execute("", opts)
+
+		// Verify error
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "search query cannot be empty")
+	})
+
+	t.Run("handles special characters in search", func(t *testing.T) {
+		// Create store with special characters
+		store := testutil.CreatePopulatedStore(t,
+			"Task with (parentheses)",
+			"Email: user@example.com",
+			"Price: $99.99",
+			"C++ programming task",
+			"Normal task without special chars",
+		)
+
+		// Test various special character searches
+		testCases := []struct {
+			query         string
+			expectedCount int
+		}{
+			{"(parentheses)", 1},
+			{"@example", 1},
+			{"$99", 1},
+			{"C++", 1},
+		}
+
+		opts := search.Options{
+			CollectionPath: store.Path(),
+			CaseSensitive:  false,
+		}
+
+		for _, tc := range testCases {
+			result, err := search.Execute(tc.query, opts)
+			testutil.AssertNoError(t, err)
+			assert.Equal(t, tc.expectedCount, len(result.MatchedTodos),
+				"Query '%s' should match %d todos", tc.query, tc.expectedCount)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Added comprehensive tests for all previously untested commands (init, list, modify, reorder, search)
- Each test file demonstrates proper use of the testutil package
- All tests use domain-specific test helpers and assertions consistently

## Changes
- **init_test.go**: Tests initialization of new and existing todo files, plus error handling
- **list_test.go**: Tests filtering options (pending, done, all), counts, and empty collections
- **modify_test.go**: Tests text modification, status preservation, and error cases
- **reorder_test.go**: Tests todo swapping, adjacent swaps, status preservation, and edge cases
- **search_test.go**: Tests case sensitivity, partial matches, special characters, and cross-status search

## Test Coverage
All command packages now have at least one comprehensive test file that serves as guidance for:
- Using testutil fixtures (`CreatePopulatedStore`, `CreateStoreWithSpecs`)
- Using domain-specific assertions (`AssertTodoInList`, `AssertTodoHasStatus`, etc.)
- Following consistent testing patterns across the codebase

## Commits
Each test file was committed incrementally as requested:
1. test(init): add comprehensive tests for init command
2. test(list): add comprehensive tests for list command
3. test(modify): add comprehensive tests for modify command
4. test(reorder): add comprehensive tests for reorder command
5. test(search): add comprehensive tests for search command

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)