### PR TITLE
Centralize CLI messages for consistency

### DIFF
--- a/cmd/tdh/add.go
+++ b/cmd/tdh/add.go
@@ -9,10 +9,10 @@ import (
 )
 
 var addCmd = &cobra.Command{
-	Use:     "add <text>",
-	Aliases: []string{"a", "new", "create"},
-	Short:   "Add a new todo (aliases: a, new, create)",
-	Long:    `Add a new todo with the specified text.`,
+	Use:     msgAddUse,
+	Aliases: aliasesAdd,
+	Short:   msgAddShort,
+	Long:    msgAddLong,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Join all arguments as the todo text

--- a/cmd/tdh/clean.go
+++ b/cmd/tdh/clean.go
@@ -7,9 +7,9 @@ import (
 )
 
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Remove finished todos",
-	Long:  `Remove all todos marked as done from the collection.`,
+	Use:   msgCleanUse,
+	Short: msgCleanShort,
+	Long:  msgCleanLong,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")

--- a/cmd/tdh/edit.go
+++ b/cmd/tdh/edit.go
@@ -10,10 +10,10 @@ import (
 )
 
 var editCmd = &cobra.Command{
-	Use:     "edit <position> <text>",
-	Aliases: []string{"modify", "m", "e"},
-	Short:   "Edit the text of an existing todo (aliases: modify, m, e)",
-	Long:    `Edit the text of an existing todo by its position.`,
+	Use:     msgEditUse,
+	Aliases: aliasesEdit,
+	Short:   msgEditShort,
+	Long:    msgEditLong,
 	Args:    cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse position

--- a/cmd/tdh/init.go
+++ b/cmd/tdh/init.go
@@ -7,10 +7,10 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	Use:     "init",
-	Aliases: []string{"i"},
-	Short:   "Initialize a new todo collection (alias: i)",
-	Long:    `Initialize a new todo collection in the specified location or the default location (~/.todos.json).`,
+	Use:     msgInitUse,
+	Aliases: aliasesInit,
+	Short:   msgInitShort,
+	Long:    msgInitLong,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")

--- a/cmd/tdh/list.go
+++ b/cmd/tdh/list.go
@@ -12,10 +12,10 @@ var (
 )
 
 var listCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"ls"},
-	Short:   "List all todos (alias: ls)",
-	Long:    `List all todos in the collection.`,
+	Use:     msgListUse,
+	Aliases: aliasesList,
+	Short:   msgListShort,
+	Long:    msgListLong,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")
@@ -38,8 +38,8 @@ var listCmd = &cobra.Command{
 
 func init() {
 	// Add flags for filtering
-	listCmd.Flags().BoolVarP(&showDone, "done", "d", false, "print done todos")
-	listCmd.Flags().BoolVarP(&showAll, "all", "a", false, "print all todos")
+	listCmd.Flags().BoolVarP(&showDone, "done", "d", false, msgFlagDone)
+	listCmd.Flags().BoolVarP(&showAll, "all", "a", false, msgFlagAll)
 
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/tdh/main.go
+++ b/cmd/tdh/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	if err := Execute(); err != nil {
-		log.Error().Err(err).Msg("Command failed")
+		log.Error().Err(err).Msg(msgCommandFailed)
 		os.Exit(1)
 	}
 }

--- a/cmd/tdh/msgs.go
+++ b/cmd/tdh/msgs.go
@@ -1,0 +1,79 @@
+package main
+
+// Command descriptions
+const (
+	// Root command
+	msgRootShort   = "A simple command-line todo list manager"
+	msgRootLong    = "tdh is a simple command-line todo list manager that helps you track tasks.\nIt stores todos in a JSON file and provides commands to add, modify, toggle, and search todos."
+	msgRootVersion = "tdh version {{.Version}}\n"
+
+	// Add command
+	msgAddUse   = "add <text>"
+	msgAddShort = "Add a new todo (aliases: a, new, create)"
+	msgAddLong  = "Add a new todo with the specified text."
+
+	// Clean command
+	msgCleanUse   = "clean"
+	msgCleanShort = "Remove finished todos"
+	msgCleanLong  = "Remove all todos marked as done from the collection."
+
+	// Edit command
+	msgEditUse   = "edit <position> <text>"
+	msgEditShort = "Edit the text of an existing todo (aliases: modify, m, e)"
+	msgEditLong  = "Edit the text of an existing todo by its position."
+
+	// Init command
+	msgInitUse   = "init"
+	msgInitShort = "Initialize a new todo collection (alias: i)"
+	msgInitLong  = "Initialize a new todo collection in the specified location or the default location (~/.todos.json)."
+
+	// List command
+	msgListUse   = "list"
+	msgListShort = "List all todos (alias: ls)"
+	msgListLong  = "List all todos in the collection."
+
+	// Reorder command
+	msgReorderUse   = "reorder"
+	msgReorderShort = "Reorder todos by sorting and reassigning sequential positions (alias: r)"
+	msgReorderLong  = "Reorder todos by sorting them by their current position and reassigning sequential positions starting from 1."
+
+	// Search command
+	msgSearchUse   = "search <query>"
+	msgSearchShort = "Search for todos (alias: s)"
+	msgSearchLong  = "Search for todos containing the specified text."
+
+	// Toggle command
+	msgToggleUse   = "toggle <position>"
+	msgToggleShort = "Toggle the status of a todo (alias: t)"
+	msgToggleLong  = "Toggle the status of a todo between pending and done."
+)
+
+// Flag descriptions
+const (
+	// Global flags
+	msgFlagVerbose  = "Increase verbosity (-v, -vv, -vvv)"
+	msgFlagDataPath = "path to todo collection (default: $HOME/.todos.json)"
+
+	// List command flags
+	msgFlagDone = "print done todos"
+	msgFlagAll  = "print all todos"
+
+	// Search command flags
+	msgFlagCaseSensitive = "Perform case-sensitive search"
+)
+
+// Error messages
+const (
+	msgCommandFailed = "Command failed"
+)
+
+// Command aliases
+var (
+	aliasesAdd     = []string{"a", "new", "create"}
+	aliasesEdit    = []string{"modify", "m", "e"}
+	aliasesInit    = []string{"i"}
+	aliasesList    = []string{"ls"}
+	aliasesReorder = []string{"r"}
+	aliasesSearch  = []string{"s"}
+	aliasesToggle  = []string{"t"}
+)

--- a/cmd/tdh/reorder.go
+++ b/cmd/tdh/reorder.go
@@ -7,10 +7,10 @@ import (
 )
 
 var reorderCmd = &cobra.Command{
-	Use:     "reorder",
-	Aliases: []string{"r"},
-	Short:   "Reorder todos by sorting and reassigning sequential positions (alias: r)",
-	Long:    `Reorder todos by sorting them by their current position and reassigning sequential positions starting from 1.`,
+	Use:     msgReorderUse,
+	Aliases: aliasesReorder,
+	Short:   msgReorderShort,
+	Long:    msgReorderLong,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag

--- a/cmd/tdh/root.go
+++ b/cmd/tdh/root.go
@@ -14,10 +14,9 @@ var (
 	verbosity int
 
 	rootCmd = &cobra.Command{
-		Use:   "tdh",
-		Short: "A simple command-line todo list manager",
-		Long: `tdh is a simple command-line todo list manager that helps you track tasks.
-It stores todos in a JSON file and provides commands to add, modify, toggle, and search todos.`,
+		Use:     "tdh",
+		Short:   msgRootShort,
+		Long:    msgRootLong,
 		Version: version.Info(),
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
@@ -73,11 +72,11 @@ func init() {
 	// will be global for your application.
 
 	// Set version template
-	rootCmd.SetVersionTemplate("tdh version {{.Version}}\n")
+	rootCmd.SetVersionTemplate(msgRootVersion)
 
 	// Verbosity flag for logging
-	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "Increase verbosity (-v, -vv, -vvv)")
+	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", msgFlagVerbose)
 
 	// Add persistent flags
-	rootCmd.PersistentFlags().StringP("data-path", "p", "", "path to todo collection (default: $HOME/.todos.json)")
+	rootCmd.PersistentFlags().StringP("data-path", "p", "", msgFlagDataPath)
 }

--- a/cmd/tdh/search.go
+++ b/cmd/tdh/search.go
@@ -9,10 +9,10 @@ import (
 )
 
 var searchCmd = &cobra.Command{
-	Use:     "search <query>",
-	Aliases: []string{"s"},
-	Short:   "Search for todos (alias: s)",
-	Long:    `Search for todos containing the specified text.`,
+	Use:     msgSearchUse,
+	Aliases: aliasesSearch,
+	Short:   msgSearchShort,
+	Long:    msgSearchLong,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Join all arguments as the search query
@@ -40,6 +40,6 @@ var searchCmd = &cobra.Command{
 }
 
 func init() {
-	searchCmd.Flags().BoolP("case-sensitive", "s", false, "Perform case-sensitive search")
+	searchCmd.Flags().BoolP("case-sensitive", "s", false, msgFlagCaseSensitive)
 	rootCmd.AddCommand(searchCmd)
 }

--- a/cmd/tdh/toggle.go
+++ b/cmd/tdh/toggle.go
@@ -9,10 +9,10 @@ import (
 )
 
 var toggleCmd = &cobra.Command{
-	Use:     "toggle <position>",
-	Aliases: []string{"t"},
-	Short:   "Toggle the status of a todo (alias: t)",
-	Long:    `Toggle the status of a todo between pending and done.`,
+	Use:     msgToggleUse,
+	Aliases: aliasesToggle,
+	Short:   msgToggleShort,
+	Long:    msgToggleLong,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse position

--- a/docs/dev/20_cli-architecture.txxt
+++ b/docs/dev/20_cli-architecture.txxt
@@ -40,23 +40,41 @@ Message Management
 All user-facing text is centralized for easy maintenance:
 
 Structure:
-• Single-line messages: Constants in cmd/tdh/msgs.go
-• Multi-line content: Files in cmd/tdh/msgs/*.txt
+• Command strings: Constants in cmd/tdh/msgs.go
+  - Command descriptions (Use, Short, Long)
+  - Flag descriptions
+  - Error messages
+  - Command aliases
+• Multi-line content: Files in cmd/tdh/msgs/*.txt (for future use)
 • Embedded at compile time using Go's embed package
 
 Benefits:
+• Complete "copy deck" visibility in one place
 • Non-technical contributors can edit messages safely
 • Compile-time validation catches errors
 • No runtime string construction bugs
 • Easy to review all user-facing text
+• Consistency across all commands
 
 Example:
 ```go
 // msgs.go
-const msgPackNotFound = "pack not found: %s"
+const (
+    msgAddUse   = "add <text>"
+    msgAddShort = "Add a new todo (aliases: a, new, create)"
+    msgAddLong  = "Add a new todo with the specified text."
+)
 
-//go:embed msgs/deploy-long.txt
-var deployLongHelp string
+var aliasesAdd = []string{"a", "new", "create"}
+
+// add.go
+var addCmd = &cobra.Command{
+    Use:     msgAddUse,
+    Aliases: aliasesAdd,
+    Short:   msgAddShort,
+    Long:    msgAddLong,
+    // ...
+}
 ```
 
 Help System


### PR DESCRIPTION
## Summary
- Centralized all user-facing CLI strings into `cmd/tdh/msgs.go`
- Updated all command files to use constants instead of inline strings
- Documented the approach in the CLI architecture guide

## Motivation
Currently all user-facing CLI strings (help, usage messages, etc) are spread out amongst files. Centralizing them in `cmd/tdh/msgs.go` allows us to view the full user-facing copy deck together, making it easier to guarantee consistency.

## Changes
- Created `cmd/tdh/msgs.go` with:
  - Command descriptions (Use, Short, Long)
  - Flag descriptions
  - Error messages
  - Command aliases as variables
- Updated all command files to use these centralized constants
- Updated `docs/dev/20_cli-architecture.txxt` to document this pattern

## Benefits
- Complete visibility of all user-facing text in one place
- Easier to maintain consistency across commands
- Simpler to review and update messaging
- Foundation for potential future i18n support

## Test plan
- [x] All tests pass
- [x] Linting passes
- [x] Commands still display correct help text
- [x] No functional changes, only string organization

🤖 Generated with [Claude Code](https://claude.ai/code)