### PR TITLE
feat: Implement recursive toggle for nested todos (Milestone 2, Chunk 2.3)

### DIFF
--- a/cmd/tdh/add.go
+++ b/cmd/tdh/add.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	parentPath string
+)
+
 var addCmd = &cobra.Command{
 	Use:     msgAddUse,
 	Aliases: aliasesAdd,
@@ -18,12 +22,14 @@ var addCmd = &cobra.Command{
 		// Join all arguments as the todo text
 		text := strings.Join(args, " ")
 
-		// Get collection path from flag
+		// Get flags
 		collectionPath, _ := cmd.Flags().GetString("data-path")
+		parentPath, _ := cmd.Flags().GetString("parent")
 
 		// Call business logic
 		result, err := tdh.Add(text, tdh.AddOptions{
 			CollectionPath: collectionPath,
+			ParentPath:     parentPath,
 		})
 		if err != nil {
 			return err
@@ -36,5 +42,6 @@ var addCmd = &cobra.Command{
 }
 
 func init() {
+	addCmd.Flags().StringVar(&parentPath, "parent", "", "parent todo position path (e.g., \"1.2\")")
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/tdh/add_test.go
+++ b/cmd/tdh/add_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddCommandCLI(t *testing.T) {
+	// Create a temp directory for test data
+	tempDir := t.TempDir()
+	testDataPath := filepath.Join(tempDir, "test-todos.json")
+
+	t.Run("passes parent flag to business logic", func(t *testing.T) {
+		// We'll verify the flag is parsed correctly by checking that the command executes without error
+		// The actual business logic testing happens in the add package tests
+
+		cmd := createTestRootCommand()
+		cmd.SetArgs([]string{"add", "-p", testDataPath, "--parent", "1.2", "New sub-task"})
+
+		output := &bytes.Buffer{}
+		cmd.SetOut(output)
+		cmd.SetErr(output)
+
+		// This will fail because no todo exists at position 1.2, but that's expected
+		// We're just testing that the CLI layer parses and passes the flag
+		err := cmd.Execute()
+
+		// The error should be about parent not found, not about flag parsing
+		if err != nil {
+			assert.Contains(t, err.Error(), "parent todo not found")
+		}
+	})
+
+	t.Run("add command accepts parent flag", func(t *testing.T) {
+		cmd := createTestRootCommand()
+
+		// Test that the flag is registered
+		addSubCmd, _, err := cmd.Find([]string{"add"})
+		assert.NoError(t, err)
+		assert.NotNil(t, addSubCmd)
+
+		// Check that parent flag exists
+		parentFlag := addSubCmd.Flags().Lookup("parent")
+		assert.NotNil(t, parentFlag)
+		assert.Equal(t, "parent", parentFlag.Name)
+		assert.Equal(t, "", parentFlag.DefValue)
+		assert.Contains(t, parentFlag.Usage, "parent todo position path")
+	})
+
+	t.Run("parent flag is optional", func(t *testing.T) {
+		// Initialize the collection first
+		initCmd := createTestRootCommand()
+		initCmd.SetArgs([]string{"init", "-p", testDataPath})
+		err := initCmd.Execute()
+		assert.NoError(t, err)
+
+		// Add without parent flag should work
+		addCmd := createTestRootCommand()
+		addCmd.SetArgs([]string{"add", "-p", testDataPath, "Top level task"})
+
+		output := &bytes.Buffer{}
+		addCmd.SetOut(output)
+		addCmd.SetErr(output)
+
+		err = addCmd.Execute()
+		assert.NoError(t, err)
+	})
+
+	t.Run("parent flag works with add command", func(t *testing.T) {
+		// This test verifies that the --parent flag is accepted and processed
+		// Initialize collection
+		initCmd := createTestRootCommand()
+		initCmd.SetArgs([]string{"init", "-p", testDataPath})
+		err := initCmd.Execute()
+		assert.NoError(t, err)
+
+		// Add parent
+		addParentCmd := createTestRootCommand()
+		addParentCmd.SetArgs([]string{"add", "-p", testDataPath, "Parent task"})
+		err = addParentCmd.Execute()
+		assert.NoError(t, err)
+
+		// Add child with --parent flag - this tests that the flag is parsed correctly
+		addChildCmd := createTestRootCommand()
+		addChildCmd.SetArgs([]string{"add", "-p", testDataPath, "--parent", "1", "Child task"})
+
+		err = addChildCmd.Execute()
+		// Should succeed - the parent exists
+		assert.NoError(t, err)
+
+		// Test with non-existent parent to verify the flag is being used
+		addOrphanCmd := createTestRootCommand()
+		addOrphanCmd.SetArgs([]string{"add", "-p", testDataPath, "--parent", "99", "Orphan task"})
+
+		err = addOrphanCmd.Execute()
+		// Should fail with parent not found
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "parent todo not found")
+	})
+}
+
+// createTestRootCommand creates a fresh root command for testing
+func createTestRootCommand() *cobra.Command {
+	// Create a new root command
+	testRoot := &cobra.Command{
+		Use:   "tdh",
+		Short: "Test root",
+	}
+
+	// Add the persistent flag
+	testRoot.PersistentFlags().StringP("data-path", "p", "", "path to todo collection")
+	var testVerbosity int
+	testRoot.PersistentFlags().CountVarP(&testVerbosity, "verbose", "v", "Increase verbosity")
+
+	// Create a fresh add command for this test to avoid state pollution
+	testAddCmd := &cobra.Command{
+		Use:     msgAddUse,
+		Aliases: aliasesAdd,
+		Short:   msgAddShort,
+		Long:    msgAddLong,
+		Args:    cobra.MinimumNArgs(1),
+		RunE:    addCmd.RunE, // Use the same RunE function
+	}
+
+	// Add the parent flag to the fresh add command
+	testAddCmd.Flags().StringVar(&parentPath, "parent", "", "parent todo position path (e.g., \"1.2\")")
+
+	// Add all commands
+	testRoot.AddCommand(testAddCmd)
+	testRoot.AddCommand(listCmd)
+	testRoot.AddCommand(initCmd)
+
+	return testRoot
+}

--- a/cmd/tdh/toggle.go
+++ b/cmd/tdh/toggle.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"strconv"
-
 	"github.com/arthur-debert/tdh/pkg/tdh"
 	"github.com/arthur-debert/tdh/pkg/tdh/output"
 	"github.com/spf13/cobra"
@@ -15,17 +13,14 @@ var toggleCmd = &cobra.Command{
 	Long:    msgToggleLong,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Parse position
-		position, err := strconv.Atoi(args[0])
-		if err != nil {
-			return err
-		}
+		// Get position path (can be simple "1" or nested "1.2.3")
+		positionPath := args[0]
 
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")
 
 		// Call business logic
-		result, err := tdh.Toggle(position, tdh.ToggleOptions{
+		result, err := tdh.Toggle(positionPath, tdh.ToggleOptions{
 			CollectionPath: collectionPath,
 		})
 		if err != nil {

--- a/docs/design/nested-lists.txxt
+++ b/docs/design/nested-lists.txxt
@@ -1,6 +1,6 @@
                 Nested Lists Design Specification
 
-NOTE: This is a proposed feature that has not been implemented yet.
+NOTE: This feature has been partially implemented. See implementation status below.
 
 This document outlines the design for implementing arbitrarily nested
 todo lists in tdh.
@@ -37,7 +37,10 @@ todo lists in tdh.
         intuitive behavior:
         
         • Toggle: Toggling a parent's status (e.g., to "done") will recursively 
-          apply the same status to all of its descendants.
+          apply the same status to all of its descendants. This maintains the 
+          invariant that a parent and all its children must have the same status.
+          A "done" task cannot have "pending" subtasks, as this would be logically
+          inconsistent - you cannot complete a task if its subtasks are incomplete.
         • Delete: Deleting a parent will delete all of its descendants by default. 
           An --unwrap flag will be provided to delete the parent but promote its 
           children to the parent's level, preventing accidental mass deletion.
@@ -104,3 +107,35 @@ todo lists in tdh.
         removed or toggled, the reordering of Position numbers will only 
         affect the direct siblings of that item. This ensures that unrelated 
         branches of the list remain stable and predictable.
+
+
+5. Implementation Status
+
+    As of the latest update, the following features have been implemented:
+
+    Completed:
+    
+        • Data Model: The Todo struct has been extended with ID, ParentID, 
+          Position, and Items fields for nested structure support.
+        
+        • FindItemByPositionPath: The core function for traversing the hierarchy
+          using dot-notation paths (e.g., "1.2.3") is fully implemented.
+        
+        • Add Command with --parent: Users can create nested todos using the
+          --parent flag with position paths.
+        
+        • Recursive Toggle: Toggling a parent applies the same status to all
+          descendants, maintaining the invariant that a parent cannot be "done"
+          if any children are "pending".
+        
+        • Hierarchical Display: The ls command shows nested todos with proper
+          indentation and dot-notation paths.
+        
+        • Migration: Automatic migration of flat lists to the new structure.
+
+    Not Yet Implemented:
+    
+        • Move Command: Relocating items within the hierarchy.
+        • Delete with --unwrap: Option to delete parent while promoting children.
+        • List --depth flag: Controlling display depth.
+        • Context-aware reordering: Currently reorders entire tree.

--- a/docs/design/nested-lists.txxt
+++ b/docs/design/nested-lists.txxt
@@ -1,6 +1,6 @@
                 Nested Lists Design Specification
 
-NOTE: This feature has been partially implemented. See implementation status below.
+NOTE: This is a proposed feature that has not been implemented yet.
 
 This document outlines the design for implementing arbitrarily nested
 todo lists in tdh.
@@ -107,35 +107,3 @@ todo lists in tdh.
         removed or toggled, the reordering of Position numbers will only 
         affect the direct siblings of that item. This ensures that unrelated 
         branches of the list remain stable and predictable.
-
-
-5. Implementation Status
-
-    As of the latest update, the following features have been implemented:
-
-    Completed:
-    
-        • Data Model: The Todo struct has been extended with ID, ParentID, 
-          Position, and Items fields for nested structure support.
-        
-        • FindItemByPositionPath: The core function for traversing the hierarchy
-          using dot-notation paths (e.g., "1.2.3") is fully implemented.
-        
-        • Add Command with --parent: Users can create nested todos using the
-          --parent flag with position paths.
-        
-        • Recursive Toggle: Toggling a parent applies the same status to all
-          descendants, maintaining the invariant that a parent cannot be "done"
-          if any children are "pending".
-        
-        • Hierarchical Display: The ls command shows nested todos with proper
-          indentation and dot-notation paths.
-        
-        • Migration: Automatic migration of flat lists to the new structure.
-
-    Not Yet Implemented:
-    
-        • Move Command: Relocating items within the hierarchy.
-        • Delete with --unwrap: Option to delete parent while promoting children.
-        • List --depth flag: Controlling display depth.
-        • Context-aware reordering: Currently reorders entire tree.

--- a/pkg/tdh/commands.go
+++ b/pkg/tdh/commands.go
@@ -53,9 +53,9 @@ func Modify(position int, newText string, opts ModifyOptions) (*ModifyResult, er
 	return cmdModify.Execute(position, newText, opts)
 }
 
-// Toggle toggles the status of a todo by position
-func Toggle(position int, opts ToggleOptions) (*ToggleResult, error) {
-	return cmdToggle.Execute(position, opts)
+// Toggle toggles the status of a todo by position path
+func Toggle(positionPath string, opts ToggleOptions) (*ToggleResult, error) {
+	return cmdToggle.Execute(positionPath, opts)
 }
 
 // Clean removes finished todos from the collection

--- a/pkg/tdh/commands/add/add.go
+++ b/pkg/tdh/commands/add/add.go
@@ -10,6 +10,7 @@ import (
 // Options contains options for the add command
 type Options struct {
 	CollectionPath string
+	ParentPath     string // Position path of parent todo (e.g., "1.2")
 }
 
 // Result contains the result of the add command
@@ -28,7 +29,18 @@ func Execute(text string, opts Options) (*Result, error) {
 
 	err := s.Update(func(collection *models.Collection) error {
 		var err error
-		todo, err = collection.CreateTodo(text, "")
+		var parentID string
+
+		// If parent path is specified, find the parent todo
+		if opts.ParentPath != "" {
+			parent, err := collection.FindItemByPositionPath(opts.ParentPath)
+			if err != nil {
+				return fmt.Errorf("parent todo not found: %w", err)
+			}
+			parentID = parent.ID
+		}
+
+		todo, err = collection.CreateTodo(text, parentID)
 		return err
 	})
 

--- a/pkg/tdh/commands/toggle/toggle.go
+++ b/pkg/tdh/commands/toggle/toggle.go
@@ -2,9 +2,10 @@ package toggle
 
 import (
 	"fmt"
+	"time"
 
-	"github.com/arthur-debert/tdh/pkg/tdh/internal/helpers"
 	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/store"
 )
 
 // Options contains options for the toggle command
@@ -19,13 +20,24 @@ type Result struct {
 	NewStatus string
 }
 
-// Execute toggles the status of a todo
-func Execute(position int, opts Options) (*Result, error) {
+// Execute toggles the status of a todo and all its children
+func Execute(positionPath string, opts Options) (*Result, error) {
 	var result *Result
 
-	err := helpers.TransactOnTodo(opts.CollectionPath, position, func(todo *models.Todo, collection *models.Collection) error {
+	s := store.NewStore(opts.CollectionPath)
+	err := s.Update(func(collection *models.Collection) error {
+		// Find the todo by position path
+		todo, err := collection.FindItemByPositionPath(positionPath)
+		if err != nil {
+			return fmt.Errorf("todo not found: %w", err)
+		}
+
+		// Capture old status
 		oldStatus := string(todo.Status)
-		todo.Toggle()
+
+		// Toggle the todo and all its children recursively
+		toggleRecursive(todo)
+
 		newStatus := string(todo.Status)
 
 		// Auto-reorder after toggle
@@ -42,8 +54,35 @@ func Execute(position int, opts Options) (*Result, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("todo not found: %w", err)
+		return nil, err
 	}
 
 	return result, nil
+}
+
+// toggleRecursive toggles a todo and all its children to match the parent's new status
+func toggleRecursive(todo *models.Todo) {
+	// Toggle the parent
+	todo.Toggle()
+
+	// Apply the parent's new status to all children recursively
+	timestamp := time.Now()
+	for _, child := range todo.Items {
+		child.Status = todo.Status
+		child.Modified = timestamp
+		// Recursively apply to grandchildren
+		applyStatusRecursive(child, todo.Status, timestamp)
+	}
+}
+
+// applyStatusRecursive applies a status to a todo and all its descendants
+func applyStatusRecursive(todo *models.Todo, status models.TodoStatus, timestamp time.Time) {
+	todo.Status = status
+	todo.Modified = timestamp
+
+	for _, child := range todo.Items {
+		child.Status = status
+		child.Modified = timestamp
+		applyStatusRecursive(child, status, timestamp)
+	}
 }

--- a/pkg/tdh/commands/toggle/toggle.go
+++ b/pkg/tdh/commands/toggle/toggle.go
@@ -41,7 +41,10 @@ func Execute(positionPath string, opts Options) (*Result, error) {
 			newStatus = models.StatusPending
 		}
 
-		// Apply the new status to the todo and all its descendants
+		// Apply the new status to the todo and all its descendants.
+		// Business Rule: A parent's status must match all its children.
+		// A "done" item cannot have "pending" children, and vice versa.
+		// This ensures logical consistency in the task hierarchy.
 		applyStatusRecursive(todo, newStatus, time.Now())
 
 		newStatusStr := string(newStatus)
@@ -66,7 +69,9 @@ func Execute(positionPath string, opts Options) (*Result, error) {
 	return result, nil
 }
 
-// applyStatusRecursive applies a status to a todo and all its descendants
+// applyStatusRecursive applies a status to a todo and all its descendants.
+// This ensures the invariant that a parent and all its children must have
+// the same status - a completed task cannot have incomplete subtasks.
 func applyStatusRecursive(todo *models.Todo, status models.TodoStatus, timestamp time.Time) {
 	todo.Status = status
 	todo.Modified = timestamp

--- a/pkg/tdh/testutil/setup.go
+++ b/pkg/tdh/testutil/setup.go
@@ -74,3 +74,39 @@ func TempDir(t *testing.T) string {
 	t.Helper()
 	return t.TempDir()
 }
+
+// CreateNestedStore creates a file-based store with a nested todo structure for testing.
+// The created structure looks like:
+//  1. Parent todo
+//     1.1 Sub-task 1.1
+//     1.2 Sub-task 1.2
+//     1.2.1 Grandchild 1.2.1
+//  2. Another top-level todo
+func CreateNestedStore(t *testing.T) store.Store {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.json")
+	s := store.NewStore(dbPath)
+
+	collection := models.NewCollection()
+
+	// Create parent todo
+	parent, _ := collection.CreateTodo("Parent todo", "")
+
+	// Create sub-tasks
+	_, _ = collection.CreateTodo("Sub-task 1.1", parent.ID)
+	subTask2, _ := collection.CreateTodo("Sub-task 1.2", parent.ID)
+
+	// Create grandchild
+	_, _ = collection.CreateTodo("Grandchild 1.2.1", subTask2.ID)
+
+	// Create another top-level todo
+	_, _ = collection.CreateTodo("Another top-level todo", "")
+
+	if err := s.Save(collection); err != nil {
+		t.Fatalf("failed to save collection: %v", err)
+	}
+
+	return s
+}


### PR DESCRIPTION
## Summary
- Implemented recursive toggle functionality for nested todos
- Toggle command now accepts position paths (e.g., "1", "1.2", "1.2.3")
- When a parent is toggled, all descendants are set to the same status

## Changes
- Updated `cmd/tdh/toggle.go` to accept position path strings instead of integers
- Modified `pkg/tdh/commands/toggle/toggle.go` to use `FindItemByPositionPath` and implement recursive toggling
- Added `toggleRecursive` and `applyStatusRecursive` helper functions
- Created comprehensive test suite for nested toggle scenarios
- Added `CreateNestedStore` test helper in testutil package

## Behavior
When toggling a parent todo:
- The parent's status changes (pending ↔ done)
- All children and descendants are set to the parent's new status
- All items receive the same modified timestamp
- Siblings of the toggled item remain unchanged

## Test plan
- [x] Unit tests for toggling nested todos at various depths
- [x] Tests for recursive status propagation
- [x] Tests for error handling (invalid paths, empty paths, etc.)
- [x] Tests verifying siblings are not affected
- [x] Tests for timestamp consistency
- [x] All existing tests continue to pass
- [x] Linter passes with no issues

Closes #52 (partially - chunk 2.3 of 3)

🤖 Generated with [Claude Code](https://claude.ai/code)