### PR TITLE
feat: Implement complete and reopen commands (Milestone 3.1)

### DIFF
--- a/cmd/tdh/complete.go
+++ b/cmd/tdh/complete.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/arthur-debert/tdh/pkg/tdh"
+	"github.com/arthur-debert/tdh/pkg/tdh/output"
+	"github.com/spf13/cobra"
+)
+
+var completeCmd = &cobra.Command{
+	Use:     msgCompleteUse,
+	Aliases: aliasesComplete,
+	Short:   msgCompleteShort,
+	Long:    msgCompleteLong,
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get collection path from flag
+		collectionPath, _ := cmd.Flags().GetString("data-path")
+
+		// Call business logic for each position path
+		var results []*tdh.CompleteResult
+		for _, positionPath := range args {
+			result, err := tdh.Complete(positionPath, tdh.CompleteOptions{
+				CollectionPath: collectionPath,
+			})
+			if err != nil {
+				return err
+			}
+			results = append(results, result)
+		}
+
+		// Render output
+		renderer := output.NewRenderer(nil)
+		return renderer.RenderComplete(results)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completeCmd)
+}

--- a/cmd/tdh/msgs.go
+++ b/cmd/tdh/msgs.go
@@ -46,6 +46,16 @@ const (
 	msgToggleUse   = "toggle <position>"
 	msgToggleShort = "Toggle the status of a todo (alias: t)"
 	msgToggleLong  = "Toggle the status of a todo between pending and done."
+
+	// Complete command
+	msgCompleteUse   = "complete <positions...>"
+	msgCompleteShort = "Mark todos as complete (alias: c)"
+	msgCompleteLong  = "Mark one or more todos as complete. Use dot notation for nested items (e.g., 1.2)."
+
+	// Reopen command
+	msgReopenUse   = "reopen <positions...>"
+	msgReopenShort = "Mark todos as pending (alias: o)"
+	msgReopenLong  = "Mark one or more todos as pending. Use dot notation for nested items (e.g., 1.2)."
 )
 
 // Flag descriptions
@@ -69,11 +79,13 @@ const (
 
 // Command aliases
 var (
-	aliasesAdd     = []string{"a", "new", "create"}
-	aliasesEdit    = []string{"modify", "m", "e"}
-	aliasesInit    = []string{"i"}
-	aliasesList    = []string{"ls"}
-	aliasesReorder = []string{"r"}
-	aliasesSearch  = []string{"s"}
-	aliasesToggle  = []string{"t"}
+	aliasesAdd      = []string{"a", "new", "create"}
+	aliasesEdit     = []string{"modify", "m", "e"}
+	aliasesInit     = []string{"i"}
+	aliasesList     = []string{"ls"}
+	aliasesReorder  = []string{"r"}
+	aliasesSearch   = []string{"s"}
+	aliasesToggle   = []string{"t"}
+	aliasesComplete = []string{"c"}
+	aliasesReopen   = []string{"o"}
 )

--- a/cmd/tdh/reopen.go
+++ b/cmd/tdh/reopen.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/arthur-debert/tdh/pkg/tdh"
+	"github.com/arthur-debert/tdh/pkg/tdh/output"
+	"github.com/spf13/cobra"
+)
+
+var reopenCmd = &cobra.Command{
+	Use:     msgReopenUse,
+	Aliases: aliasesReopen,
+	Short:   msgReopenShort,
+	Long:    msgReopenLong,
+	Args:    cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get collection path from flag
+		collectionPath, _ := cmd.Flags().GetString("data-path")
+
+		// Call business logic for each position path
+		var results []*tdh.ReopenResult
+		for _, positionPath := range args {
+			result, err := tdh.Reopen(positionPath, tdh.ReopenOptions{
+				CollectionPath: collectionPath,
+			})
+			if err != nil {
+				return err
+			}
+			results = append(results, result)
+		}
+
+		// Render output
+		renderer := output.NewRenderer(nil)
+		return renderer.RenderReopen(results)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(reopenCmd)
+}

--- a/pkg/tdh/commands.go
+++ b/pkg/tdh/commands.go
@@ -6,9 +6,11 @@ package tdh
 import (
 	cmdAdd "github.com/arthur-debert/tdh/pkg/tdh/commands/add"
 	cmdClean "github.com/arthur-debert/tdh/pkg/tdh/commands/clean"
+	cmdComplete "github.com/arthur-debert/tdh/pkg/tdh/commands/complete"
 	cmdInit "github.com/arthur-debert/tdh/pkg/tdh/commands/init"
 	cmdList "github.com/arthur-debert/tdh/pkg/tdh/commands/list"
 	cmdModify "github.com/arthur-debert/tdh/pkg/tdh/commands/modify"
+	cmdReopen "github.com/arthur-debert/tdh/pkg/tdh/commands/reopen"
 	cmdReorder "github.com/arthur-debert/tdh/pkg/tdh/commands/reorder"
 	cmdSearch "github.com/arthur-debert/tdh/pkg/tdh/commands/search"
 	cmdToggle "github.com/arthur-debert/tdh/pkg/tdh/commands/toggle"
@@ -16,26 +18,30 @@ import (
 
 // Re-export command option types for backward compatibility
 type (
-	InitOptions    = cmdInit.Options
-	AddOptions     = cmdAdd.Options
-	ModifyOptions  = cmdModify.Options
-	ToggleOptions  = cmdToggle.Options
-	CleanOptions   = cmdClean.Options
-	ReorderOptions = cmdReorder.Options
-	SearchOptions  = cmdSearch.Options
-	ListOptions    = cmdList.Options
+	InitOptions     = cmdInit.Options
+	AddOptions      = cmdAdd.Options
+	ModifyOptions   = cmdModify.Options
+	ToggleOptions   = cmdToggle.Options
+	CompleteOptions = cmdComplete.Options
+	ReopenOptions   = cmdReopen.Options
+	CleanOptions    = cmdClean.Options
+	ReorderOptions  = cmdReorder.Options
+	SearchOptions   = cmdSearch.Options
+	ListOptions     = cmdList.Options
 )
 
 // Re-export command result types for backward compatibility
 type (
-	InitResult    = cmdInit.Result
-	AddResult     = cmdAdd.Result
-	ModifyResult  = cmdModify.Result
-	ToggleResult  = cmdToggle.Result
-	CleanResult   = cmdClean.Result
-	ReorderResult = cmdReorder.Result
-	SearchResult  = cmdSearch.Result
-	ListResult    = cmdList.Result
+	InitResult     = cmdInit.Result
+	AddResult      = cmdAdd.Result
+	ModifyResult   = cmdModify.Result
+	ToggleResult   = cmdToggle.Result
+	CompleteResult = cmdComplete.Result
+	ReopenResult   = cmdReopen.Result
+	CleanResult    = cmdClean.Result
+	ReorderResult  = cmdReorder.Result
+	SearchResult   = cmdSearch.Result
+	ListResult     = cmdList.Result
 )
 
 // Init initializes a new todo collection
@@ -56,6 +62,16 @@ func Modify(position int, newText string, opts ModifyOptions) (*ModifyResult, er
 // Toggle toggles the status of a todo by position path
 func Toggle(positionPath string, opts ToggleOptions) (*ToggleResult, error) {
 	return cmdToggle.Execute(positionPath, opts)
+}
+
+// Complete marks a todo as complete by position path
+func Complete(positionPath string, opts CompleteOptions) (*CompleteResult, error) {
+	return cmdComplete.Execute(positionPath, opts)
+}
+
+// Reopen marks a todo as pending by position path
+func Reopen(positionPath string, opts ReopenOptions) (*ReopenResult, error) {
+	return cmdReopen.Execute(positionPath, opts)
 }
 
 // Clean removes finished todos from the collection

--- a/pkg/tdh/commands/complete/complete.go
+++ b/pkg/tdh/commands/complete/complete.go
@@ -1,0 +1,83 @@
+package complete
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/tdh/pkg/logging"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/store"
+)
+
+// Options contains options for the complete command
+type Options struct {
+	CollectionPath string
+}
+
+// Result contains the result of the complete command
+type Result struct {
+	Todo      *models.Todo
+	OldStatus string
+	NewStatus string
+}
+
+// Execute marks a todo as complete
+func Execute(positionPath string, opts Options) (*Result, error) {
+	logger := logging.GetLogger("tdh.commands.complete")
+	logger.Debug().
+		Str("positionPath", positionPath).
+		Str("collectionPath", opts.CollectionPath).
+		Msg("executing complete command")
+
+	var result *Result
+
+	s := store.NewStore(opts.CollectionPath)
+	err := s.Update(func(collection *models.Collection) error {
+		// Find the todo by position path
+		todo, err := collection.FindItemByPositionPath(positionPath)
+		if err != nil {
+			logger.Error().
+				Err(err).
+				Str("positionPath", positionPath).
+				Msg("failed to find todo")
+			return fmt.Errorf("todo not found: %w", err)
+		}
+
+		// Capture old status
+		oldStatus := string(todo.Status)
+
+		// According to the spec, complete only affects the specified item
+		// No propagation to children
+		todo.Status = models.StatusDone
+		todo.Modified = time.Now()
+
+		logger.Debug().
+			Str("todoID", todo.ID).
+			Str("oldStatus", oldStatus).
+			Str("newStatus", string(todo.Status)).
+			Msg("marked todo as complete")
+
+		// Auto-reorder after status change
+		collection.Reorder()
+
+		// Capture result
+		result = &Result{
+			Todo:      todo,
+			OldStatus: oldStatus,
+			NewStatus: string(todo.Status),
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info().
+		Str("positionPath", positionPath).
+		Str("todoText", result.Todo.Text).
+		Msg("successfully completed todo")
+
+	return result, nil
+}

--- a/pkg/tdh/commands/complete/complete_test.go
+++ b/pkg/tdh/commands/complete/complete_test.go
@@ -117,6 +117,20 @@ func TestComplete(t *testing.T) {
 		assert.Contains(t, err.Error(), "todo not found")
 	})
 
+	t.Run("complete invalid position path format", func(t *testing.T) {
+		// Setup
+		store := testutil.CreateNestedStore(t)
+
+		// Execute - invalid format with non-numeric part
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("1.a.2", opts)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "invalid position")
+	})
+
 	t.Run("complete already done todo", func(t *testing.T) {
 		// Setup
 		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{

--- a/pkg/tdh/commands/complete/complete_test.go
+++ b/pkg/tdh/commands/complete/complete_test.go
@@ -1,0 +1,137 @@
+package complete_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/complete"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplete(t *testing.T) {
+	t.Run("complete simple todo", func(t *testing.T) {
+		// Setup
+		store := testutil.CreatePopulatedStore(t, "Test todo 1", "Test todo 2")
+
+		// Execute
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Test todo 1", result.Todo.Text)
+		assert.Equal(t, "pending", result.OldStatus)
+		assert.Equal(t, "done", result.NewStatus)
+		assert.Equal(t, models.StatusDone, result.Todo.Status)
+
+		// Verify it was saved
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		todo := testutil.AssertTodoByPosition(t, collection.Todos, 1)
+		testutil.AssertTodoHasStatus(t, todo, models.StatusDone)
+
+		// Verify other todo is still pending
+		todo2 := testutil.AssertTodoByPosition(t, collection.Todos, 2)
+		testutil.AssertTodoHasStatus(t, todo2, models.StatusPending)
+	})
+
+	t.Run("complete nested todo", func(t *testing.T) {
+		// Setup - create nested structure
+		store := testutil.CreateNestedStore(t)
+
+		// Execute - complete child todo
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("1.1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Sub-task 1.1", result.Todo.Text)
+		assert.Equal(t, "pending", result.OldStatus)
+		assert.Equal(t, "done", result.NewStatus)
+		assert.Equal(t, models.StatusDone, result.Todo.Status)
+
+		// Verify parent is still pending
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		parent, err := collection.FindItemByPositionPath("1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, parent.Status)
+
+		// Verify only the specific child was marked done
+		child, err := collection.FindItemByPositionPath("1.1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusDone, child.Status)
+
+		// Verify sibling is still pending
+		sibling, err := collection.FindItemByPositionPath("1.2")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, sibling.Status)
+	})
+
+	t.Run("complete grandchild todo", func(t *testing.T) {
+		// Setup - create nested structure
+		store := testutil.CreateNestedStore(t)
+
+		// Execute - complete grandchild
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("1.2.1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Grandchild 1.2.1", result.Todo.Text)
+		assert.Equal(t, "pending", result.OldStatus)
+		assert.Equal(t, "done", result.NewStatus)
+
+		// Verify only the specific item was affected
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+
+		item, err := collection.FindItemByPositionPath("1.2.1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusDone, item.Status)
+
+		// Verify all parents remain pending
+		paths := []string{"1", "1.2"}
+		for _, path := range paths {
+			parent, err := collection.FindItemByPositionPath(path)
+			testutil.AssertNoError(t, err)
+			assert.Equal(t, models.StatusPending, parent.Status, "Parent at %s should remain pending", path)
+		}
+	})
+
+	t.Run("complete invalid position", func(t *testing.T) {
+		// Setup
+		store := testutil.CreatePopulatedStore(t, "Test todo")
+
+		// Execute
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("99", opts)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "todo not found")
+	})
+
+	t.Run("complete already done todo", func(t *testing.T) {
+		// Setup
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Already done", Status: models.StatusDone},
+		})
+
+		// Execute
+		opts := complete.Options{CollectionPath: store.Path()}
+		result, err := complete.Execute("1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Already done", result.Todo.Text)
+		assert.Equal(t, "done", result.OldStatus)
+		assert.Equal(t, "done", result.NewStatus)
+		assert.Equal(t, models.StatusDone, result.Todo.Status)
+	})
+}

--- a/pkg/tdh/commands/reopen/reopen.go
+++ b/pkg/tdh/commands/reopen/reopen.go
@@ -1,0 +1,83 @@
+package reopen
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/arthur-debert/tdh/pkg/logging"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/store"
+)
+
+// Options contains options for the reopen command
+type Options struct {
+	CollectionPath string
+}
+
+// Result contains the result of the reopen command
+type Result struct {
+	Todo      *models.Todo
+	OldStatus string
+	NewStatus string
+}
+
+// Execute marks a todo as pending
+func Execute(positionPath string, opts Options) (*Result, error) {
+	logger := logging.GetLogger("tdh.commands.reopen")
+	logger.Debug().
+		Str("positionPath", positionPath).
+		Str("collectionPath", opts.CollectionPath).
+		Msg("executing reopen command")
+
+	var result *Result
+
+	s := store.NewStore(opts.CollectionPath)
+	err := s.Update(func(collection *models.Collection) error {
+		// Find the todo by position path
+		todo, err := collection.FindItemByPositionPath(positionPath)
+		if err != nil {
+			logger.Error().
+				Err(err).
+				Str("positionPath", positionPath).
+				Msg("failed to find todo")
+			return fmt.Errorf("todo not found: %w", err)
+		}
+
+		// Capture old status
+		oldStatus := string(todo.Status)
+
+		// According to the spec, reopen only affects the specified item
+		// No propagation in any direction
+		todo.Status = models.StatusPending
+		todo.Modified = time.Now()
+
+		logger.Debug().
+			Str("todoID", todo.ID).
+			Str("oldStatus", oldStatus).
+			Str("newStatus", string(todo.Status)).
+			Msg("marked todo as pending")
+
+		// Auto-reorder after status change
+		collection.Reorder()
+
+		// Capture result
+		result = &Result{
+			Todo:      todo,
+			OldStatus: oldStatus,
+			NewStatus: string(todo.Status),
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info().
+		Str("positionPath", positionPath).
+		Str("todoText", result.Todo.Text).
+		Msg("successfully reopened todo")
+
+	return result, nil
+}

--- a/pkg/tdh/commands/reopen/reopen_test.go
+++ b/pkg/tdh/commands/reopen/reopen_test.go
@@ -1,0 +1,188 @@
+package reopen_test
+
+import (
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/reopen"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReopen(t *testing.T) {
+	t.Run("reopen simple todo", func(t *testing.T) {
+		// Setup
+		store := testutil.CreateStoreWithSpecs(t, []testutil.TodoSpec{
+			{Text: "Test todo 1", Status: models.StatusDone},
+			{Text: "Test todo 2", Status: models.StatusPending},
+		})
+
+		// Execute
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Test todo 1", result.Todo.Text)
+		assert.Equal(t, "done", result.OldStatus)
+		assert.Equal(t, "pending", result.NewStatus)
+		assert.Equal(t, models.StatusPending, result.Todo.Status)
+
+		// Verify it was saved
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		todo := testutil.AssertTodoByPosition(t, collection.Todos, 1)
+		testutil.AssertTodoHasStatus(t, todo, models.StatusPending)
+		todo2 := testutil.AssertTodoByPosition(t, collection.Todos, 2)
+		testutil.AssertTodoHasStatus(t, todo2, models.StatusPending)
+	})
+
+	t.Run("reopen nested todo", func(t *testing.T) {
+		// Setup - create nested structure
+		store := testutil.CreateNestedStore(t)
+
+		// Mark a child as done first
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		child, err := collection.FindItemByPositionPath("1.1")
+		testutil.AssertNoError(t, err)
+		child.Status = models.StatusDone
+		err = store.Save(collection)
+		testutil.AssertNoError(t, err)
+
+		// Execute - reopen child todo
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1.1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Sub-task 1.1", result.Todo.Text)
+		assert.Equal(t, "done", result.OldStatus)
+		assert.Equal(t, "pending", result.NewStatus)
+		assert.Equal(t, models.StatusPending, result.Todo.Status)
+
+		// Verify parent remains unchanged
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		parent, err := collection.FindItemByPositionPath("1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, parent.Status)
+
+		// Verify only the specific child was reopened
+		child, err = collection.FindItemByPositionPath("1.1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, child.Status)
+	})
+
+	t.Run("reopen grandchild todo", func(t *testing.T) {
+		// Setup - create nested structure
+		store := testutil.CreateNestedStore(t)
+
+		// Mark grandchild as done
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		item, err := collection.FindItemByPositionPath("1.2.1")
+		testutil.AssertNoError(t, err)
+		item.Status = models.StatusDone
+		err = store.Save(collection)
+		testutil.AssertNoError(t, err)
+
+		// Execute - reopen grandchild
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1.2.1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, "Grandchild 1.2.1", result.Todo.Text)
+		assert.Equal(t, "done", result.OldStatus)
+		assert.Equal(t, "pending", result.NewStatus)
+
+		// Verify only the specific item was affected
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+
+		item, err = collection.FindItemByPositionPath("1.2.1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, item.Status)
+
+		// Verify no propagation happened
+		paths := []string{"1", "1.2"}
+		for _, path := range paths {
+			parent, err := collection.FindItemByPositionPath(path)
+			testutil.AssertNoError(t, err)
+			assert.Equal(t, models.StatusPending, parent.Status, "Parent at %s should remain unchanged", path)
+		}
+	})
+
+	t.Run("reopen invalid position", func(t *testing.T) {
+		// Setup
+		store := testutil.CreatePopulatedStore(t, "Test todo")
+
+		// Execute
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("99", opts)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "todo not found")
+	})
+
+	t.Run("reopen already pending todo", func(t *testing.T) {
+		// Setup
+		store := testutil.CreatePopulatedStore(t, "Already pending")
+
+		// Execute
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1", opts)
+
+		// Assert
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Already pending", result.Todo.Text)
+		assert.Equal(t, "pending", result.OldStatus)
+		assert.Equal(t, "pending", result.NewStatus)
+		assert.Equal(t, models.StatusPending, result.Todo.Status)
+	})
+
+	t.Run("reopen with parent done", func(t *testing.T) {
+		// Setup - create nested structure
+		store := testutil.CreateNestedStore(t)
+
+		// Mark parent and child as done
+		collection, err := store.Load()
+		testutil.AssertNoError(t, err)
+		parent, err := collection.FindItemByPositionPath("1")
+		testutil.AssertNoError(t, err)
+		parent.Status = models.StatusDone
+		child, err := collection.FindItemByPositionPath("1.1")
+		testutil.AssertNoError(t, err)
+		child.Status = models.StatusDone
+		err = store.Save(collection)
+		testutil.AssertNoError(t, err)
+
+		// Execute - reopen child when parent is done
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1.1", opts)
+
+		// Assert - should still work per spec (no propagation)
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, "Sub-task 1.1", result.Todo.Text)
+		assert.Equal(t, "done", result.OldStatus)
+		assert.Equal(t, "pending", result.NewStatus)
+
+		// Verify parent remains done
+		collection, err = store.Load()
+		testutil.AssertNoError(t, err)
+		parent, err = collection.FindItemByPositionPath("1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusDone, parent.Status)
+
+		// Verify child is now pending
+		child, err = collection.FindItemByPositionPath("1.1")
+		testutil.AssertNoError(t, err)
+		assert.Equal(t, models.StatusPending, child.Status)
+	})
+}

--- a/pkg/tdh/commands/reopen/reopen_test.go
+++ b/pkg/tdh/commands/reopen/reopen_test.go
@@ -131,6 +131,20 @@ func TestReopen(t *testing.T) {
 		assert.Contains(t, err.Error(), "todo not found")
 	})
 
+	t.Run("reopen invalid position path format", func(t *testing.T) {
+		// Setup
+		store := testutil.CreateNestedStore(t)
+
+		// Execute - invalid format with non-numeric part
+		opts := reopen.Options{CollectionPath: store.Path()}
+		result, err := reopen.Execute("1.a.2", opts)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "invalid position")
+	})
+
 	t.Run("reopen already pending todo", func(t *testing.T) {
 		// Setup
 		store := testutil.CreatePopulatedStore(t, "Already pending")

--- a/pkg/tdh/output/renderer.go
+++ b/pkg/tdh/output/renderer.go
@@ -284,6 +284,36 @@ func (r *LipbamlRenderer) RenderList(result *tdh.ListResult) error {
 	return err
 }
 
+// RenderComplete renders the complete command results using lipbalm
+func (r *LipbamlRenderer) RenderComplete(results []*tdh.CompleteResult) error {
+	for _, result := range results {
+		output, err := r.renderTemplate("complete_result", result)
+		if err != nil {
+			return fmt.Errorf("failed to render complete result: %w", err)
+		}
+		_, err = fmt.Fprintln(r.writer, output)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RenderReopen renders the reopen command results using lipbalm
+func (r *LipbamlRenderer) RenderReopen(results []*tdh.ReopenResult) error {
+	for _, result := range results {
+		output, err := r.renderTemplate("reopen_result", result)
+		if err != nil {
+			return fmt.Errorf("failed to render reopen result: %w", err)
+		}
+		_, err = fmt.Fprintln(r.writer, output)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RenderError renders an error message
 func (r *LipbamlRenderer) RenderError(err error) error {
 	output, renderErr := r.renderTemplate("error", err.Error())

--- a/pkg/tdh/output/templates/complete_result.tmpl
+++ b/pkg/tdh/output/templates/complete_result.tmpl
@@ -1,0 +1,1 @@
+<success>✓</success> Completed: <value>{{.Todo.Text}}</value>

--- a/pkg/tdh/output/templates/reopen_result.tmpl
+++ b/pkg/tdh/output/templates/reopen_result.tmpl
@@ -1,0 +1,1 @@
+<warning>○</warning> Reopened: <value>{{.Todo.Text}}</value>


### PR DESCRIPTION
## Summary
- Implements the `complete` and `reopen` commands for milestone 3.1 of the nested lists feature
- Adds support for dot-notation paths to target nested todos (e.g., `tdh complete 1.2.3`)
- Both commands follow the specification: they only affect the specified item with no propagation

## Changes
- Added `complete` command to mark todos as done by position path
- Added `reopen` command to mark todos as pending by position path
- Created comprehensive tests for both commands
- Added output templates for consistent command feedback
- Updated CLI messages with aliases (c for complete, o for reopen)

## Test plan
- [x] Unit tests for complete command pass
- [x] Unit tests for reopen command pass
- [x] All existing tests continue to pass
- [x] Linting passes
- [x] Manual testing shows commands work correctly with nested todos
- [x] Commands correctly handle invalid positions with appropriate error messages

Closes #60

🤖 Generated with [Claude Code](https://claude.ai/code)