### PR TITLE
Revamp help output with custom template and command groups

### DIFF
--- a/cmd/tdh/add.go
+++ b/cmd/tdh/add.go
@@ -17,6 +17,7 @@ var addCmd = &cobra.Command{
 	Aliases: aliasesAdd,
 	Short:   msgAddShort,
 	Long:    msgAddLong,
+	GroupID: "core",
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Join all arguments as the todo text

--- a/cmd/tdh/add_test.go
+++ b/cmd/tdh/add_test.go
@@ -111,6 +111,13 @@ func createTestRootCommand() *cobra.Command {
 		Short: "Test root",
 	}
 
+	// Define command groups to match the main root command
+	testRoot.AddGroup(
+		&cobra.Group{ID: "core", Title: "CORE:"},
+		&cobra.Group{ID: "extras", Title: "EXTRAS:"},
+		&cobra.Group{ID: "misc", Title: "MISC:"},
+	)
+
 	// Add the persistent flag
 	testRoot.PersistentFlags().StringP("data-path", "p", "", "path to todo collection")
 	var testVerbosity int

--- a/cmd/tdh/clean.go
+++ b/cmd/tdh/clean.go
@@ -7,9 +7,10 @@ import (
 )
 
 var cleanCmd = &cobra.Command{
-	Use:   msgCleanUse,
-	Short: msgCleanShort,
-	Long:  msgCleanLong,
+	Use:     msgCleanUse,
+	Short:   msgCleanShort,
+	Long:    msgCleanLong,
+	GroupID: "misc",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")

--- a/cmd/tdh/complete.go
+++ b/cmd/tdh/complete.go
@@ -11,6 +11,7 @@ var completeCmd = &cobra.Command{
 	Aliases: aliasesComplete,
 	Short:   msgCompleteShort,
 	Long:    msgCompleteLong,
+	GroupID: "core",
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag

--- a/cmd/tdh/edit.go
+++ b/cmd/tdh/edit.go
@@ -14,6 +14,7 @@ var editCmd = &cobra.Command{
 	Aliases: aliasesEdit,
 	Short:   msgEditShort,
 	Long:    msgEditLong,
+	GroupID: "core",
 	Args:    cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse position

--- a/cmd/tdh/help.go
+++ b/cmd/tdh/help.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+// setupHelp configures custom help templates
+func setupHelp() {
+	// Add template functions
+	templateFuncs := template.FuncMap{
+		"rpad":                    rpad,
+		"bold":                    bold,
+		"commandAliases":          commandAliases,
+		"trimTrailingWhitespaces": trimTrailingWhitespaces,
+	}
+
+	// Set custom help template for root command
+	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		tmpl, err := template.New("help").Funcs(templateFuncs).Parse(helpTemplate)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		var buf bytes.Buffer
+		err = tmpl.Execute(&buf, cmd)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Print(buf.String())
+	})
+}
+
+// Template helper functions
+
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+func bold(s string) string {
+	return "\033[1m" + s + "\033[0m"
+}
+
+func commandAliases(name string, aliases []string) string {
+	if len(aliases) > 0 {
+		return fmt.Sprintf("%s,%s", name, strings.Join(aliases, ","))
+	}
+	return name
+}
+
+func trimTrailingWhitespaces(s string) string {
+	return strings.TrimRight(s, " \t\n")
+}

--- a/cmd/tdh/init.go
+++ b/cmd/tdh/init.go
@@ -11,6 +11,7 @@ var initCmd = &cobra.Command{
 	Aliases: aliasesInit,
 	Short:   msgInitShort,
 	Long:    msgInitLong,
+	GroupID: "misc",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")

--- a/cmd/tdh/list.go
+++ b/cmd/tdh/list.go
@@ -16,6 +16,7 @@ var listCmd = &cobra.Command{
 	Aliases: aliasesList,
 	Short:   msgListShort,
 	Long:    msgListLong,
+	GroupID: "extras",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag
 		collectionPath, _ := cmd.Flags().GetString("data-path")

--- a/cmd/tdh/move.go
+++ b/cmd/tdh/move.go
@@ -12,6 +12,7 @@ var moveCmd = &cobra.Command{
 	Aliases: aliasesMove,
 	Short:   msgMoveShort,
 	Long:    msgMoveLong,
+	GroupID: "extras",
 	Args:    cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sourcePath := args[0]

--- a/cmd/tdh/move.go
+++ b/cmd/tdh/move.go
@@ -8,10 +8,11 @@ import (
 )
 
 var moveCmd = &cobra.Command{
-	Use:   msgMoveUse,
-	Short: msgMoveShort,
-	Long:  msgMoveLong,
-	Args:  cobra.ExactArgs(2),
+	Use:     msgMoveUse,
+	Aliases: aliasesMove,
+	Short:   msgMoveShort,
+	Long:    msgMoveLong,
+	Args:    cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sourcePath := args[0]
 		destParentPath := args[1]

--- a/cmd/tdh/msgs.go
+++ b/cmd/tdh/msgs.go
@@ -1,15 +1,19 @@
 package main
 
+import (
+	_ "embed"
+)
+
 // Command descriptions
 const (
 	// Root command
 	msgRootShort   = "A simple command-line todo list manager"
-	msgRootLong    = "tdh is a simple command-line todo list manager that helps you track tasks.\nIt stores todos in a JSON file and provides commands to add, modify, and search todos."
+	msgRootLong    = "Fast project-aware, nested, command-line todo list."
 	msgRootVersion = "tdh version {{.Version}}\n"
 
 	// Add command
 	msgAddUse   = "add <text>"
-	msgAddShort = "Add a new todo (aliases: a, new, create)"
+	msgAddShort = "Add a new todo"
 	msgAddLong  = "Add a new todo with the specified text."
 
 	// Clean command
@@ -19,37 +23,37 @@ const (
 
 	// Edit command
 	msgEditUse   = "edit <position> <text>"
-	msgEditShort = "Edit the text of an existing todo (aliases: modify, m, e)"
+	msgEditShort = "Edit the text of an existing todo"
 	msgEditLong  = "Edit the text of an existing todo by its position."
 
 	// Init command
 	msgInitUse   = "init"
-	msgInitShort = "Initialize a new todo collection (alias: i)"
+	msgInitShort = "Initialize a new todo collection"
 	msgInitLong  = "Initialize a new todo collection in the specified location or the default location (~/.todos.json)."
 
 	// List command
 	msgListUse   = "list"
-	msgListShort = "List all todos (alias: ls)"
+	msgListShort = "List all todos"
 	msgListLong  = "List all todos in the collection."
 
 	// Reorder command
 	msgReorderUse   = "reorder"
-	msgReorderShort = "Reorder todos by sorting and reassigning sequential positions (alias: r)"
+	msgReorderShort = "Reorder todos by sorting and reassigning sequential positions"
 	msgReorderLong  = "Reorder todos by sorting them by their current position and reassigning sequential positions starting from 1."
 
 	// Search command
 	msgSearchUse   = "search <query>"
-	msgSearchShort = "Search for todos (alias: s)"
+	msgSearchShort = "Search for todos"
 	msgSearchLong  = "Search for todos containing the specified text."
 
 	// Complete command
 	msgCompleteUse   = "complete <positions...>"
-	msgCompleteShort = "Mark todos as complete (alias: c)"
+	msgCompleteShort = "Mark todos as complete"
 	msgCompleteLong  = "Mark one or more todos as complete. Use dot notation for nested items (e.g., 1.2)."
 
 	// Reopen command
 	msgReopenUse   = "reopen <positions...>"
-	msgReopenShort = "Mark todos as pending (alias: o)"
+	msgReopenShort = "Mark todos as pending"
 	msgReopenLong  = "Mark one or more todos as pending. Use dot notation for nested items (e.g., 1.2)."
 
 	// Move command
@@ -80,11 +84,15 @@ const (
 // Command aliases
 var (
 	aliasesAdd      = []string{"a", "new", "create"}
-	aliasesEdit     = []string{"modify", "m", "e"}
+	aliasesEdit     = []string{"modify", "e"}
 	aliasesInit     = []string{"i"}
 	aliasesList     = []string{"ls"}
 	aliasesReorder  = []string{"r"}
 	aliasesSearch   = []string{"s"}
 	aliasesComplete = []string{"c"}
 	aliasesReopen   = []string{"o"}
+	aliasesMove     = []string{"m"}
 )
+
+//go:embed templates/help.txt
+var helpTemplate string

--- a/cmd/tdh/reopen.go
+++ b/cmd/tdh/reopen.go
@@ -11,6 +11,7 @@ var reopenCmd = &cobra.Command{
 	Aliases: aliasesReopen,
 	Short:   msgReopenShort,
 	Long:    msgReopenLong,
+	GroupID: "core",
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag

--- a/cmd/tdh/reorder.go
+++ b/cmd/tdh/reorder.go
@@ -11,6 +11,7 @@ var reorderCmd = &cobra.Command{
 	Aliases: aliasesReorder,
 	Short:   msgReorderShort,
 	Long:    msgReorderLong,
+	GroupID: "extras",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get collection path from flag

--- a/cmd/tdh/root.go
+++ b/cmd/tdh/root.go
@@ -79,4 +79,7 @@ func init() {
 
 	// Add persistent flags
 	rootCmd.PersistentFlags().StringP("data-path", "p", "", msgFlagDataPath)
+
+	// Setup custom help
+	setupHelp()
 }

--- a/cmd/tdh/root.go
+++ b/cmd/tdh/root.go
@@ -74,6 +74,13 @@ func init() {
 	// Set version template
 	rootCmd.SetVersionTemplate(msgRootVersion)
 
+	// Define command groups
+	rootCmd.AddGroup(
+		&cobra.Group{ID: "core", Title: "CORE:"},
+		&cobra.Group{ID: "extras", Title: "EXTRAS:"},
+		&cobra.Group{ID: "misc", Title: "MISC:"},
+	)
+
 	// Verbosity flag for logging
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", msgFlagVerbose)
 

--- a/cmd/tdh/search.go
+++ b/cmd/tdh/search.go
@@ -13,6 +13,7 @@ var searchCmd = &cobra.Command{
 	Aliases: aliasesSearch,
 	Short:   msgSearchShort,
 	Long:    msgSearchLong,
+	GroupID: "extras",
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Join all arguments as the search query

--- a/cmd/tdh/templates/help.txt
+++ b/cmd/tdh/templates/help.txt
@@ -1,0 +1,24 @@
+{{.Long}}
+
+{{ bold "USAGE:" }}
+  tdh init                    # creates a new todo list here  
+  tdh add "Buy Groceries"
+      Added todo #1: Buy Groceries
+  tdh add --parent 1 "Milk"
+  tdh complete 1.1            # completes todo item 1 (Groceries)'s first item (Milk)
+  tdh reopen 1.1              # My bad, we still need milk
+  tdh search bread
+
+{{ bold "CORE:" }}{{range .Commands}}{{if (or (eq .Name "add") (eq .Name "complete") (eq .Name "edit") (eq .Name "reopen"))}}
+  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
+
+{{ bold "EXTRAS:" }}{{range .Commands}}{{if (or (eq .Name "list") (eq .Name "move") (eq .Name "reorder") (eq .Name "search"))}}
+  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
+
+{{ bold "MISC:" }}{{range .Commands}}{{if (or (eq .Name "clean") (eq .Name "init") (eq .Name "help"))}}
+  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
+
+{{ bold "FLAGS:" }}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+
+Use "tdh help [command]" for more info on a command.

--- a/cmd/tdh/templates/help.txt
+++ b/cmd/tdh/templates/help.txt
@@ -9,14 +9,10 @@
   tdh reopen 1.1              # My bad, we still need milk
   tdh search bread
 
-{{ bold "CORE:" }}{{range .Commands}}{{if (or (eq .Name "add") (eq .Name "complete") (eq .Name "edit") (eq .Name "reopen"))}}
-  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
+{{range $group := .Groups}}{{ bold $group.Title }}{{range $cmd := $.Commands}}{{if eq $cmd.GroupID $group.ID}}
+  {{rpad (commandAliases $cmd.Name $cmd.Aliases) 15}} : {{$cmd.Short}}{{end}}{{end}}
 
-{{ bold "EXTRAS:" }}{{range .Commands}}{{if (or (eq .Name "list") (eq .Name "move") (eq .Name "reorder") (eq .Name "search"))}}
-  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
-
-{{ bold "MISC:" }}{{range .Commands}}{{if (or (eq .Name "clean") (eq .Name "init") (eq .Name "help"))}}
-  {{rpad (commandAliases .Name .Aliases) 15}} : {{.Short}}{{end}}{{end}}
+{{end}}
 
 {{ bold "FLAGS:" }}
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}


### PR DESCRIPTION
## Summary
- Implements a custom help template with improved formatting and organization
- Uses Cobra's command groups feature for cleaner, more maintainable code
- Enhances user experience with practical examples and better visual hierarchy

## Changes

### Custom Help Template
- Created `cmd/tdh/templates/help.txt` with embedded template using Go's `embed` feature
- Added bold section headers (USAGE, CORE, EXTRAS, MISC, FLAGS) for better readability
- Included practical examples in USAGE section showing common workflows
- Display command aliases inline (e.g., `add,a,new,create`) for better discoverability

### Command Organization
- Leveraged Cobra's native command groups feature instead of hardcoding lists
- Commands organized into three logical groups:
  - **CORE**: add, complete, edit, reopen (essential daily operations)
  - **EXTRAS**: list, move, reorder, search (additional functionality)
  - **MISC**: clean, init, help (maintenance and setup)
- Each command now has a `GroupID` property for automatic categorization

### Implementation Details
- Added `help.go` with template functions for formatting (bold, rpad, etc.)
- Updated root command description to be more concise and impactful
- Removed redundant alias information from command descriptions
- Fixed alias conflict between edit and move commands (both had 'm')
- Updated test helper to include command groups for consistency

## Example Output
```
Fast project-aware, nested, command-line todo list.

USAGE:
  tdh init                    # creates a new todo list here  
  tdh add "Buy Groceries"
      Added todo #1: Buy Groceries
  tdh add --parent 1 "Milk"
  tdh complete 1.1            # completes todo item 1 (Groceries)'s first item (Milk)
  tdh reopen 1.1              # My bad, we still need milk
  tdh search bread

CORE:
  add,a,new,create : Add a new todo
  complete,c      : Mark todos as complete
  edit,modify,e   : Edit the text of an existing todo
  reopen,o        : Mark todos as pending

EXTRAS:
  list,ls         : List all todos
  move,m          : Move a todo to a different parent
  reorder,r       : Reorder todos by sorting and reassigning sequential positions
  search,s        : Search for todos

MISC:
  clean           : Remove finished todos
  init,i          : Initialize a new todo collection

FLAGS:
  -p, --data-path string   path to todo collection (default: $HOME/.todos.json)
  -h, --help               help for tdh
  -v, --verbose count      Increase verbosity (-v, -vv, -vvv)
      --version            version for tdh
```

## Testing
- All existing tests pass
- Updated `createTestRootCommand` helper to include command groups
- Manually verified help output formatting and content

## Benefits
- **Better User Experience**: Clear examples and organized command groups make it easier for new users
- **Maintainability**: Using Cobra's groups feature means new commands automatically appear in the right section
- **Consistency**: All formatting and organization logic centralized in the template
- **Future-proof**: Easy to add new groups or reorganize commands without touching the template

🤖 Generated with [Claude Code](https://claude.ai/code)