### PR TITLE
Fix: Make tdh init create .todos file in current directory by default

### DIFF
--- a/cmd/tdh/init.go
+++ b/cmd/tdh/init.go
@@ -5,6 +5,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var initUseHomeDir bool
+
 var initCmd = &cobra.Command{
 	Use:     msgInitUse,
 	Aliases: aliasesInit,
@@ -17,7 +19,8 @@ var initCmd = &cobra.Command{
 
 		// Call business logic
 		result, err := tdh.Init(tdh.InitOptions{
-			DBPath: collectionPath,
+			DBPath:     collectionPath,
+			UseHomeDir: initUseHomeDir,
 		})
 		if err != nil {
 			return err
@@ -34,4 +37,5 @@ var initCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().BoolVar(&initUseHomeDir, "home", false, "Create .todos file in home directory instead of current directory")
 }

--- a/pkg/tdh/commands/init/init.go
+++ b/pkg/tdh/commands/init/init.go
@@ -2,6 +2,8 @@ package init
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/arthur-debert/tdh/pkg/tdh/models"
 	"github.com/arthur-debert/tdh/pkg/tdh/store"
@@ -9,7 +11,8 @@ import (
 
 // Options contains options for the init command
 type Options struct {
-	DBPath string
+	DBPath     string
+	UseHomeDir bool // Create .todos file in home directory instead of current directory
 }
 
 // Result contains the result of the init command
@@ -21,7 +24,24 @@ type Result struct {
 
 // Execute initializes a new todo collection
 func Execute(opts Options) (*Result, error) {
-	s := store.NewStore(opts.DBPath)
+	var storePath string
+
+	if opts.DBPath != "" {
+		// Use explicit path if provided
+		storePath = opts.DBPath
+	} else if opts.UseHomeDir {
+		// Use home directory
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+		storePath = filepath.Join(home, ".todos.json")
+	} else {
+		// Use current directory (default)
+		storePath = ".todos.json"
+	}
+
+	s := store.NewStore(storePath)
 
 	if !s.Exists() {
 		// Create an empty collection to initialize the file

--- a/pkg/tdh/commands/init/init_test.go
+++ b/pkg/tdh/commands/init/init_test.go
@@ -35,6 +35,46 @@ func TestInitCommand(t *testing.T) {
 		testutil.AssertCollectionSize(t, collection, 0)
 	})
 
+	t.Run("creates todo file in current directory by default", func(t *testing.T) {
+		// Setup temp directory and change to it
+		dir := t.TempDir()
+		oldDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(dir)
+		require.NoError(t, err)
+		defer func() {
+			_ = os.Chdir(oldDir) // Restore original directory
+		}()
+
+		// Execute init command without explicit path
+		opts := cmdinit.Options{}
+		result, err := cmdinit.Execute(opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		assert.True(t, result.Created)
+		assert.Equal(t, ".todos.json", result.DBPath)
+		assert.Contains(t, result.Message, "Initialized empty tdh collection")
+
+		// Verify file was created in current directory
+		expectedPath := filepath.Join(dir, ".todos.json")
+		_, err = os.Stat(expectedPath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("creates todo file in home directory with UseHomeDir flag", func(t *testing.T) {
+		// Execute init command with UseHomeDir
+		opts := cmdinit.Options{UseHomeDir: true}
+		result, err := cmdinit.Execute(opts)
+
+		// Verify results
+		testutil.AssertNoError(t, err)
+		home, _ := os.UserHomeDir()
+		expectedPath := filepath.Join(home, ".todos.json")
+		assert.Equal(t, expectedPath, result.DBPath)
+		assert.Contains(t, result.Message, "tdh collection")
+	})
+
 	t.Run("reinitializes when file already exists", func(t *testing.T) {
 		// Create a populated store using testutil
 		s := testutil.CreatePopulatedStore(t, "Existing todo 1", "Existing todo 2")

--- a/scripts/run-integration-env.sh
+++ b/scripts/run-integration-env.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Get the project root directory (where this script is located)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Usage function
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] [TODOS_FILE]
+
+Create an isolated testing environment for tdh commands with a temporary data store.
+
+Arguments:
+  TODOS_FILE    Optional .todos file to populate the test environment with.
+                If not provided, a fresh .todos file will be initialized.
+
+Options:
+  -h, --help    Show this help message and exit
+
+Description:
+  This script creates a temporary directory with an isolated .todos file for
+  testing tdh commands. It drops you into a new shell session where you can
+  run tdh commands without affecting your real todo data. The temporary
+  environment is automatically cleaned up when you exit the shell.
+
+Examples:
+  # Start with a fresh .todos file
+  $(basename "$0")
+
+  # Start with a copy of an existing .todos file
+  $(basename "$0") ~/.todos.json
+
+  # Start with a test data file
+  $(basename "$0") test/fixtures/sample.todos.json
+
+EOF
+}
+
+# Parse arguments
+TODOS_FILE=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -z "$TODOS_FILE" ]]; then
+                TODOS_FILE="$1"
+            else
+                echo -e "${RED}Error: Too many arguments${NC}" >&2
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate todos file if provided
+if [[ -n "$TODOS_FILE" ]]; then
+    if [[ ! -f "$TODOS_FILE" ]]; then
+        echo -e "${RED}Error: File '$TODOS_FILE' does not exist${NC}" >&2
+        exit 1
+    fi
+    # Convert to absolute path
+    TODOS_FILE="$(cd "$(dirname "$TODOS_FILE")" && pwd)/$(basename "$TODOS_FILE")"
+fi
+
+# Ensure tmp directory exists
+TMP_BASE="$PROJECT_ROOT/tmp"
+mkdir -p "$TMP_BASE"
+
+# Create a unique temporary directory
+TEMP_DIR=$(mktemp -d "$TMP_BASE/tdh-test-XXXXXX")
+
+# Build tdh if needed
+TDH_BIN="$PROJECT_ROOT/bin/tdh"
+if [[ ! -x "$TDH_BIN" ]]; then
+    echo -e "${YELLOW}Building tdh...${NC}"
+    (cd "$PROJECT_ROOT" && ./scripts/build)
+fi
+
+# Function to cleanup on exit
+cleanup() {
+    echo -e "\n${YELLOW}Cleaning up test environment...${NC}"
+    if [[ -d "$TEMP_DIR" ]]; then
+        rm -rf "$TEMP_DIR"
+        echo -e "${GREEN}Test environment cleaned up${NC}"
+    fi
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT INT TERM
+
+# Change to temp directory
+cd "$TEMP_DIR"
+
+# Initialize or copy todos file
+if [[ -n "$TODOS_FILE" ]]; then
+    echo -e "${BLUE}Copying todos file from: $TODOS_FILE${NC}"
+    cp "$TODOS_FILE" .todos.json
+    echo -e "${GREEN}Test environment initialized with existing data${NC}"
+else
+    echo -e "${BLUE}Initializing fresh .todos file${NC}"
+    "$TDH_BIN" init
+fi
+
+# Display environment info
+echo -e "\n${GREEN}=== Test Environment Ready ===${NC}"
+echo -e "Working directory: ${BLUE}$TEMP_DIR${NC}"
+echo -e "Using tdh binary: ${BLUE}$TDH_BIN${NC}"
+echo -e "Data file: ${BLUE}$TEMP_DIR/.todos.json${NC}"
+echo -e "\n${YELLOW}Type 'exit' or press Ctrl+D to leave and cleanup${NC}\n"
+
+# Create a custom prompt to indicate test environment
+export PS1="[tdh-test] \w $ "
+
+# Add project bin to PATH for easy tdh access
+export PATH="$PROJECT_ROOT/bin:$PATH"
+
+# Start a new shell
+exec bash --norc


### PR DESCRIPTION
## Summary
- Changes `tdh init` to create `.todos.json` in the current directory by default
- Adds `--home` flag to create the file in the home directory when needed
- Includes integration test script for isolated testing environments

## Problem
Previously, `tdh init` would always create the `.todos` file in the user's home directory (`~/.todos.json`), which was counterintuitive. Users typically expect initialization commands to create files in the current directory where they run the command (similar to `git init`, `npm init`, etc.).

## Solution
1. Modified `pkg/tdh/commands/init/init.go` to:
   - Create `.todos.json` in the current directory by default
   - Accept a `UseHomeDir` boolean option
   - Create in home directory only when `UseHomeDir` is true

2. Updated `cmd/tdh/init.go` to:
   - Add a `--home` flag
   - Pass the flag value to the init command options

3. Added comprehensive unit tests to verify:
   - Default behavior creates in current directory
   - `--home` flag creates in home directory
   - Explicit path overrides both behaviors

## Additional Changes
- Added `scripts/run-integration-env.sh` for isolated testing environments
- This script creates a temporary directory with its own `.todos` file for safe testing

## Test plan
- [x] Unit tests pass for all new behavior
- [x] Manual testing confirms `tdh init` creates in current directory
- [x] Manual testing confirms `tdh init --home` creates in home directory
- [x] Integration test script works correctly
- [x] All existing tests pass
- [x] Linter passes

Fixes #106

🤖 Generated with [Claude Code](https://claude.ai/code)