### PR TITLE
Fix: Properly indent multi-line todos in output

### DIFF
--- a/pkg/tdh/output/renderer_test.go
+++ b/pkg/tdh/output/renderer_test.go
@@ -1,0 +1,75 @@
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatMultilineText(t *testing.T) {
+	tests := []struct {
+		name        string
+		text        string
+		baseIndent  string
+		columnWidth int
+		expected    string
+		description string
+	}{
+		{
+			name:        "single line text unchanged",
+			text:        "Single line todo",
+			baseIndent:  "",
+			columnWidth: 6,
+			expected:    "Single line todo",
+			description: "Single line text should remain unchanged",
+		},
+		{
+			name:        "two line text with indentation",
+			text:        "First line\nSecond line",
+			baseIndent:  "",
+			columnWidth: 6,
+			expected:    "First line\n                 Second line",
+			description: "Second line should be indented to align with first line text",
+		},
+		{
+			name:        "multiple lines with base indent",
+			text:        "Line one\nLine two\nLine three",
+			baseIndent:  "    ",
+			columnWidth: 6,
+			expected:    "Line one\n                     Line two\n                     Line three",
+			description: "All continuation lines should have consistent indentation",
+		},
+		{
+			name:        "empty lines preserved",
+			text:        "First\n\nThird",
+			baseIndent:  "",
+			columnWidth: 6,
+			expected:    "First\n                 \n                 Third",
+			description: "Empty lines should be preserved with proper indentation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatMultilineText(tt.text, tt.baseIndent, tt.columnWidth)
+			assert.Equal(t, tt.expected, result, tt.description)
+
+			// Verify that continuation lines have the expected indentation
+			if strings.Contains(tt.text, "\n") {
+				lines := strings.Split(result, "\n")
+				if len(lines) > 1 {
+					// Calculate expected indent: baseIndent + columnWidth + 11 (for " | X ")
+					expectedIndentLen := len(tt.baseIndent) + tt.columnWidth + 11
+					for i := 1; i < len(lines); i++ {
+						if lines[i] != "" { // Skip empty lines for this check
+							actualIndent := len(lines[i]) - len(strings.TrimLeft(lines[i], " "))
+							assert.GreaterOrEqual(t, actualIndent, expectedIndentLen,
+								"Line %d should have at least %d spaces of indentation", i+1, expectedIndentLen)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes multi-line todo text formatting in both terminal and markdown output
- Adds proper indentation for continuation lines to maintain visual hierarchy
- Includes comprehensive tests for the new formatting behavior

## Problem
When todos contain multiple lines (newlines in the text), the output didn't properly indent continuation lines. This made it difficult to visually distinguish where one todo ends and another begins.

### Before:
```
1 | ✕ Hello, item one
2 | ✕ Hello, Item two, multiline
continues here
3 | ✕ Hello, item three
```

### After:
```
1 | ✕ Hello, item one
2 | ✕ Hello, Item two, multiline
      continues here
3 | ✕ Hello, item three
```

## Solution
1. Added `formatMultilineText` helper function in the terminal renderer
2. Added `formatMultilineMarkdown` helper function in the markdown formatter
3. Updated rendering logic to detect and properly format multi-line text
4. Ensured consistent indentation that accounts for:
   - Position number column width
   - Separator and status symbols
   - Base indentation for nested todos

## Testing
- Added unit tests for the formatting functions
- Added integration tests for markdown formatter with multi-line todos
- Manually tested using the integration environment script:
  - Single-line todos remain unchanged
  - Multi-line todos have properly indented continuation lines
  - Nested multi-line todos maintain correct indentation hierarchy
  - Both terminal and markdown outputs format correctly

## Test plan
- [x] Unit tests pass for formatting functions
- [x] Integration tests pass for markdown formatter
- [x] Manual testing with integration environment shows correct formatting
- [x] Nested todos with multi-line text display correctly
- [x] All existing tests continue to pass
- [x] Linter passes

Fixes #108

🤖 Generated with [Claude Code](https://claude.ai/code)