### PR TITLE
feat: Add CSV format support

### DIFF
--- a/cmd/tdh/register_formatters.go
+++ b/cmd/tdh/register_formatters.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/arthur-debert/tdh/pkg/tdh/formatter"
 	"github.com/arthur-debert/tdh/pkg/tdh/output"
+	"github.com/arthur-debert/tdh/pkg/tdh/output/formatters/csv"
 	"github.com/arthur-debert/tdh/pkg/tdh/output/formatters/json"
 	"github.com/arthur-debert/tdh/pkg/tdh/output/formatters/markdown"
 	"github.com/arthur-debert/tdh/pkg/tdh/output/formatters/term"
@@ -17,6 +18,19 @@ func init() {
 
 // registerBuiltinFormatters registers all built-in formatters.
 func registerBuiltinFormatters() {
+	// Register CSV formatter
+	if err := output.Register(&output.FormatterInfo{
+		Info: formatter.Info{
+			Name:        "csv",
+			Description: "CSV output for spreadsheet applications",
+		},
+		Factory: func() (output.Formatter, error) {
+			return csv.New(), nil
+		},
+	}); err != nil {
+		panic(fmt.Sprintf("failed to register csv formatter: %v", err))
+	}
+
 	// Register JSON formatter
 	if err := output.Register(&output.FormatterInfo{
 		Info: formatter.Info{
@@ -29,7 +43,7 @@ func registerBuiltinFormatters() {
 	}); err != nil {
 		panic(fmt.Sprintf("failed to register json formatter: %v", err))
 	}
-	
+
 	// Register Markdown formatter
 	if err := output.Register(&output.FormatterInfo{
 		Info: formatter.Info{
@@ -42,7 +56,7 @@ func registerBuiltinFormatters() {
 	}); err != nil {
 		panic(fmt.Sprintf("failed to register markdown formatter: %v", err))
 	}
-	
+
 	// Register Terminal formatter
 	if err := output.Register(&output.FormatterInfo{
 		Info: formatter.Info{

--- a/pkg/tdh/output/formatters/csv/formatter.go
+++ b/pkg/tdh/output/formatters/csv/formatter.go
@@ -1,0 +1,278 @@
+package csv
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/arthur-debert/tdh/pkg/tdh"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	"github.com/arthur-debert/tdh/pkg/tdh/output"
+)
+
+// formatter implements the Formatter interface for CSV output
+type formatter struct{}
+
+// New creates a new CSV formatter
+func New() output.Formatter {
+	return &formatter{}
+}
+
+// Name returns the formatter name
+func (f *formatter) Name() string {
+	return "csv"
+}
+
+// Description returns the formatter description
+func (f *formatter) Description() string {
+	return "CSV output for spreadsheet applications"
+}
+
+// writeCSV is a helper that writes CSV data
+func (f *formatter) writeCSV(w io.Writer, headers []string, rows [][]string) error {
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	// Write headers
+	if err := writer.Write(headers); err != nil {
+		return err
+	}
+
+	// Write rows
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+
+	return writer.Error()
+}
+
+// flattenTodos converts a hierarchical todo structure to flat CSV rows
+func (f *formatter) flattenTodos(todos []*models.Todo, parentPath string) [][]string {
+	var rows [][]string
+
+	for _, todo := range todos {
+		// Build the current path
+		currentPath := todo.Text
+		if parentPath != "" {
+			currentPath = parentPath + " > " + todo.Text
+		}
+
+		// Add the current todo as a row
+		row := []string{
+			todo.ID,
+			parentPath, // parent column for hierarchy
+			fmt.Sprintf("%d", todo.Position),
+			todo.Text,
+			string(todo.Status),
+			todo.Modified.Format("2006-01-02T15:04:05"),
+		}
+		rows = append(rows, row)
+
+		// Recursively add child todos
+		if len(todo.Items) > 0 {
+			childRows := f.flattenTodos(todo.Items, currentPath)
+			rows = append(rows, childRows...)
+		}
+	}
+
+	return rows
+}
+
+// RenderAdd renders the add command result as CSV
+func (f *formatter) RenderAdd(w io.Writer, result *tdh.AddResult) error {
+	headers := []string{"id", "parent", "position", "text", "status", "modified"}
+	rows := f.flattenTodos([]*models.Todo{result.Todo}, "")
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderModify renders the modify command result as CSV
+func (f *formatter) RenderModify(w io.Writer, result *tdh.ModifyResult) error {
+	headers := []string{"id", "parent", "position", "text", "status", "modified", "old_text"}
+	rows := [][]string{{
+		result.Todo.ID,
+		"",
+		fmt.Sprintf("%d", result.Todo.Position),
+		result.Todo.Text,
+		string(result.Todo.Status),
+		result.Todo.Modified.Format("2006-01-02T15:04:05"),
+		result.OldText,
+	}}
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderInit renders the init command result as CSV
+func (f *formatter) RenderInit(w io.Writer, result *tdh.InitResult) error {
+	headers := []string{"message", "path", "created"}
+	rows := [][]string{{result.Message, result.DBPath, fmt.Sprintf("%t", result.Created)}}
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderClean renders the clean command result as CSV
+func (f *formatter) RenderClean(w io.Writer, result *tdh.CleanResult) error {
+	headers := []string{"operation", "removed_count", "active_count"}
+	rows := [][]string{{
+		"clean",
+		fmt.Sprintf("%d", result.RemovedCount),
+		fmt.Sprintf("%d", result.ActiveCount),
+	}}
+
+	// If there are removed todos, add them
+	if len(result.RemovedTodos) > 0 {
+		if err := f.writeCSV(w, headers, rows); err != nil {
+			return err
+		}
+		// Write a blank line
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		// Write removed todos
+		todoHeaders := []string{"id", "parent", "position", "text", "status", "modified"}
+		todoRows := f.flattenTodos(result.RemovedTodos, "")
+		return f.writeCSV(w, todoHeaders, todoRows)
+	}
+
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderSearch renders the search command result as CSV
+func (f *formatter) RenderSearch(w io.Writer, result *tdh.SearchResult) error {
+	headers := []string{"id", "parent", "position", "text", "status", "modified", "matched"}
+	var rows [][]string
+
+	for _, todo := range result.MatchedTodos {
+		// Determine if this todo matched or if it's included because a child matched
+		matched := "direct"
+		if !strings.Contains(strings.ToLower(todo.Text), strings.ToLower(result.Query)) {
+			matched = "child"
+		}
+
+		row := []string{
+			todo.ID,
+			"",
+			fmt.Sprintf("%d", todo.Position),
+			todo.Text,
+			string(todo.Status),
+			todo.Modified.Format("2006-01-02T15:04:05"),
+			matched,
+		}
+		rows = append(rows, row)
+
+		// Add child todos
+		if len(todo.Items) > 0 {
+			childRows := f.flattenTodos(todo.Items, todo.Text)
+			// Update matched status for children
+			for i := range childRows {
+				childRows[i] = append(childRows[i], "direct")
+			}
+			rows = append(rows, childRows...)
+		}
+	}
+
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderList renders the list command result as CSV
+func (f *formatter) RenderList(w io.Writer, result *tdh.ListResult) error {
+	// First write summary
+	summaryHeaders := []string{"total_count", "done_count", "pending_count"}
+	summaryRows := [][]string{{
+		fmt.Sprintf("%d", result.TotalCount),
+		fmt.Sprintf("%d", result.DoneCount),
+		fmt.Sprintf("%d", result.TotalCount-result.DoneCount),
+	}}
+
+	if err := f.writeCSV(w, summaryHeaders, summaryRows); err != nil {
+		return err
+	}
+
+	// Write a blank line
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	// Then write todos
+	headers := []string{"id", "parent", "position", "text", "status", "modified"}
+	rows := f.flattenTodos(result.Todos, "")
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderComplete renders the complete command results as CSV
+func (f *formatter) RenderComplete(w io.Writer, results []*tdh.CompleteResult) error {
+	headers := []string{"id", "parent", "position", "text", "status", "modified"}
+	var rows [][]string
+
+	for _, result := range results {
+		todoRows := f.flattenTodos([]*models.Todo{result.Todo}, "")
+		rows = append(rows, todoRows...)
+	}
+
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderReopen renders the reopen command results as CSV
+func (f *formatter) RenderReopen(w io.Writer, results []*tdh.ReopenResult) error {
+	headers := []string{"id", "parent", "position", "text", "status", "modified"}
+	var rows [][]string
+
+	for _, result := range results {
+		todoRows := f.flattenTodos([]*models.Todo{result.Todo}, "")
+		rows = append(rows, todoRows...)
+	}
+
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderMove renders the move command result as CSV
+func (f *formatter) RenderMove(w io.Writer, result *tdh.MoveResult) error {
+	headers := []string{"id", "text", "old_path", "new_path", "status"}
+	rows := [][]string{{
+		result.Todo.ID,
+		result.Todo.Text,
+		result.OldPath,
+		result.NewPath,
+		string(result.Todo.Status),
+	}}
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderSwap renders the swap command result as CSV
+func (f *formatter) RenderSwap(w io.Writer, result *tdh.SwapResult) error {
+	headers := []string{"id", "text", "old_path", "new_path", "status"}
+	rows := [][]string{{
+		result.Todo.ID,
+		result.Todo.Text,
+		result.OldPath,
+		result.NewPath,
+		string(result.Todo.Status),
+	}}
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderDataPath renders the datapath command result as CSV
+func (f *formatter) RenderDataPath(w io.Writer, result *tdh.ShowDataPathResult) error {
+	headers := []string{"data_path"}
+	rows := [][]string{{result.Path}}
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderFormats renders the formats command result as CSV
+func (f *formatter) RenderFormats(w io.Writer, result *tdh.ListFormatsResult) error {
+	headers := []string{"name", "description"}
+	var rows [][]string
+
+	for _, format := range result.Formats {
+		rows = append(rows, []string{format.Name, format.Description})
+	}
+
+	return f.writeCSV(w, headers, rows)
+}
+
+// RenderError renders an error message as CSV
+func (f *formatter) RenderError(w io.Writer, err error) error {
+	headers := []string{"error"}
+	rows := [][]string{{err.Error()}}
+	return f.writeCSV(w, headers, rows)
+}

--- a/pkg/tdh/output/formatters/csv/formatter_test.go
+++ b/pkg/tdh/output/formatters/csv/formatter_test.go
@@ -1,0 +1,265 @@
+package csv_test
+
+import (
+	"bytes"
+	"encoding/csv"
+	"strings"
+	"testing"
+
+	"github.com/arthur-debert/tdh/pkg/tdh"
+	"github.com/arthur-debert/tdh/pkg/tdh/commands/formats"
+	"github.com/arthur-debert/tdh/pkg/tdh/models"
+	csvformatter "github.com/arthur-debert/tdh/pkg/tdh/output/formatters/csv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCSVFormatter(t *testing.T) {
+	formatter := csvformatter.New()
+
+	t.Run("Name and Description", func(t *testing.T) {
+		assert.Equal(t, "csv", formatter.Name())
+		assert.Equal(t, "CSV output for spreadsheet applications", formatter.Description())
+	})
+
+	t.Run("RenderAdd", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.AddResult{
+			Todo: &models.Todo{
+				ID:       "123",
+				Position: 1,
+				Text:     "Test todo",
+				Status:   models.StatusPending,
+			},
+		}
+
+		err := formatter.RenderAdd(&buf, result)
+		require.NoError(t, err)
+
+		// Parse CSV
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		// Check headers
+		assert.Equal(t, []string{"id", "parent", "position", "text", "status", "modified"}, records[0])
+
+		// Check data
+		assert.Len(t, records, 2) // header + 1 row
+		assert.Equal(t, "123", records[1][0])
+		assert.Equal(t, "", records[1][1]) // no parent
+		assert.Equal(t, "1", records[1][2])
+		assert.Equal(t, "Test todo", records[1][3])
+		assert.Equal(t, "pending", records[1][4])
+	})
+
+	t.Run("RenderList", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.ListResult{
+			Todos: []*models.Todo{
+				{
+					ID:       "1",
+					Position: 1,
+					Text:     "First todo",
+					Status:   models.StatusPending,
+				},
+				{
+					ID:       "2",
+					Position: 2,
+					Text:     "Second todo, with comma",
+					Status:   models.StatusDone,
+				},
+			},
+			TotalCount: 2,
+			DoneCount:  1,
+		}
+
+		err := formatter.RenderList(&buf, result)
+		require.NoError(t, err)
+
+		// Split by blank line
+		parts := strings.Split(buf.String(), "\n\n")
+		require.Len(t, parts, 2)
+
+		// Parse summary CSV
+		summaryReader := csv.NewReader(strings.NewReader(parts[0]))
+		summaryRecords, err := summaryReader.ReadAll()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"total_count", "done_count", "pending_count"}, summaryRecords[0])
+		assert.Equal(t, []string{"2", "1", "1"}, summaryRecords[1])
+
+		// Parse todos CSV
+		todosReader := csv.NewReader(strings.NewReader(parts[1]))
+		todosRecords, err := todosReader.ReadAll()
+		require.NoError(t, err)
+		assert.Len(t, todosRecords, 3) // header + 2 rows
+
+		// Check that comma in text is properly escaped
+		assert.Equal(t, "Second todo, with comma", todosRecords[2][3])
+	})
+
+	t.Run("RenderError", func(t *testing.T) {
+		var buf bytes.Buffer
+		testErr := assert.AnError
+
+		err := formatter.RenderError(&buf, testErr)
+		require.NoError(t, err)
+
+		// Parse CSV
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"error"}, records[0])
+		assert.Equal(t, testErr.Error(), records[1][0])
+	})
+
+	t.Run("RenderFormats", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.ListFormatsResult{
+			Formats: []formats.Format{
+				{
+					Name:        "csv",
+					Description: "CSV output",
+				},
+				{
+					Name:        "json",
+					Description: "JSON output",
+				},
+			},
+		}
+
+		err := formatter.RenderFormats(&buf, result)
+		require.NoError(t, err)
+
+		// Parse CSV
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Len(t, records, 3) // header + 2 rows
+		assert.Equal(t, []string{"name", "description"}, records[0])
+		assert.Equal(t, "csv", records[1][0])
+		assert.Equal(t, "json", records[2][0])
+	})
+
+	t.Run("Nested todos with hierarchy", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.ListResult{
+			Todos: []*models.Todo{
+				{
+					ID:       "1",
+					Position: 1,
+					Text:     "Parent todo",
+					Status:   models.StatusPending,
+					Items: []*models.Todo{
+						{
+							ID:       "1.1",
+							Position: 1,
+							Text:     "Child todo",
+							Status:   models.StatusPending,
+							Items: []*models.Todo{
+								{
+									ID:       "1.1.1",
+									Position: 1,
+									Text:     "Grandchild todo",
+									Status:   models.StatusPending,
+								},
+							},
+						},
+					},
+				},
+			},
+			TotalCount: 3,
+			DoneCount:  0,
+		}
+
+		err := formatter.RenderList(&buf, result)
+		require.NoError(t, err)
+
+		// Split by blank line and parse todos
+		parts := strings.Split(buf.String(), "\n\n")
+		todosReader := csv.NewReader(strings.NewReader(parts[1]))
+		todosRecords, err := todosReader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Len(t, todosRecords, 4) // header + 3 rows
+
+		// Check parent hierarchy
+		assert.Equal(t, "", todosRecords[1][1])                         // Parent has no parent
+		assert.Equal(t, "Parent todo", todosRecords[2][1])              // Child's parent
+		assert.Equal(t, "Parent todo > Child todo", todosRecords[3][1]) // Grandchild's parent path
+	})
+
+	t.Run("Text with newlines", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.AddResult{
+			Todo: &models.Todo{
+				ID:       "123",
+				Position: 1,
+				Text:     "Todo with\nnewline",
+				Status:   models.StatusPending,
+			},
+		}
+
+		err := formatter.RenderAdd(&buf, result)
+		require.NoError(t, err)
+
+		// Parse CSV - the CSV package should handle newlines properly
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Len(t, records, 2)
+		assert.Equal(t, "Todo with\nnewline", records[1][3])
+	})
+
+	t.Run("Special characters", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.AddResult{
+			Todo: &models.Todo{
+				ID:       "123",
+				Position: 1,
+				Text:     `Todo with "quotes", commas, and 'apostrophes'`,
+				Status:   models.StatusPending,
+			},
+		}
+
+		err := formatter.RenderAdd(&buf, result)
+		require.NoError(t, err)
+
+		// Parse CSV
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Len(t, records, 2)
+		assert.Equal(t, `Todo with "quotes", commas, and 'apostrophes'`, records[1][3])
+	})
+
+	t.Run("RenderMove", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := &tdh.MoveResult{
+			Todo: &models.Todo{
+				ID:       "123",
+				Position: 3,
+				Text:     "Moved todo",
+				Status:   models.StatusPending,
+			},
+			OldPath: "1",
+			NewPath: "3",
+		}
+
+		err := formatter.RenderMove(&buf, result)
+		require.NoError(t, err)
+
+		// Parse CSV
+		reader := csv.NewReader(&buf)
+		records, err := reader.ReadAll()
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"id", "text", "old_path", "new_path", "status"}, records[0])
+		assert.Equal(t, "1", records[1][2]) // old path
+		assert.Equal(t, "3", records[1][3]) // new path
+	})
+}


### PR DESCRIPTION
## Summary
- Implement CSV formatter using Go's built-in encoding/csv package
- Handle hierarchical todos with parent column for flat CSV representation
- Properly escape commas, quotes, and newlines following RFC 4180

## Test plan
- [x] Unit tests for CSV formatter pass
- [x] Integration tested with various commands (`tdh list --format csv`, etc.)
- [x] Verified proper escaping of special characters (commas, quotes, newlines)
- [x] Pre-commit checks pass (lint, format, tests)
- [x] Manual testing shows correct CSV output that can be imported into spreadsheets

## Implementation Details
- Uses Go's `encoding/csv` package for proper CSV formatting
- Flattens hierarchical todos with a "parent" column to preserve structure
- Different CSV structures for different commands (summary + details for list, etc.)
- All CSV edge cases handled by the standard library

Fixes #112

🤖 Generated with [Claude Code](https://claude.ai/code)