### PR TITLE
feat: Add long and short output mode

### DIFF
--- a/cmd/tdh/add.go
+++ b/cmd/tdh/add.go
@@ -88,6 +88,7 @@ var addCmd = &cobra.Command{
 		result, err := tdh.Add(text, tdh.AddOptions{
 			CollectionPath: collectionPath,
 			ParentPath:     parentPath,
+			Mode:           modeFlag,
 		})
 		if err != nil {
 			return err

--- a/cmd/tdh/complete.go
+++ b/cmd/tdh/complete.go
@@ -21,6 +21,7 @@ var completeCmd = &cobra.Command{
 		for _, positionPath := range args {
 			result, err := tdh.Complete(positionPath, tdh.CompleteOptions{
 				CollectionPath: collectionPath,
+				Mode:           modeFlag,
 			})
 			if err != nil {
 				return err

--- a/cmd/tdh/msgs.go
+++ b/cmd/tdh/msgs.go
@@ -63,6 +63,7 @@ const (
 	msgFlagVerbose  = "Increase verbosity (-v, -vv, -vvv)"
 	msgFlagDataPath = "path to todo collection (default: $HOME/.todos.json)"
 	msgFlagFormat   = "output format (term, json, markdown)"
+	msgFlagMode     = "output mode (short, long)"
 
 	// List command flags
 	msgFlagDone = "print done todos"

--- a/cmd/tdh/root.go
+++ b/cmd/tdh/root.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	verbosity int
+	verbosity  int
 	formatFlag string
+	modeFlag   string
 
 	rootCmd = &cobra.Command{
 		Use:     "tdh",
@@ -26,6 +27,11 @@ var (
 			// Setup logging based on verbosity
 			logging.SetupLogger(verbosity)
 			log.Debug().Str("command", cmd.Name()).Msg("Command started")
+
+			// Validate mode flag
+			if modeFlag != "short" && modeFlag != "long" {
+				log.Fatal().Str("mode", modeFlag).Msg("Invalid mode flag value. Must be 'short' or 'long'")
+			}
 		},
 	}
 )
@@ -88,6 +94,7 @@ func init() {
 	// Add persistent flags
 	rootCmd.PersistentFlags().StringP("data-path", "p", "", msgFlagDataPath)
 	rootCmd.PersistentFlags().StringVarP(&formatFlag, "format", "f", "term", msgFlagFormat)
+	rootCmd.PersistentFlags().StringVarP(&modeFlag, "mode", "m", "short", msgFlagMode)
 
 	// Setup custom help
 	setupHelp()

--- a/pkg/tdh/commands/add/add.go
+++ b/pkg/tdh/commands/add/add.go
@@ -11,11 +11,16 @@ import (
 type Options struct {
 	CollectionPath string
 	ParentPath     string // Position path of parent todo (e.g., "1.2")
+	Mode           string // Output mode: "short" or "long"
 }
 
 // Result contains the result of the add command
 type Result struct {
-	Todo *models.Todo
+	Todo       *models.Todo
+	Mode       string         // Output mode passed from options
+	AllTodos   []*models.Todo // All todos for long mode
+	TotalCount int            // Total count for long mode
+	DoneCount  int            // Done count for long mode
 }
 
 // Execute adds a new todo to the collection
@@ -48,5 +53,37 @@ func Execute(text string, opts Options) (*Result, error) {
 		return nil, fmt.Errorf("failed to add todo: %w", err)
 	}
 
-	return &Result{Todo: todo}, nil
+	result := &Result{
+		Todo: todo,
+		Mode: opts.Mode,
+	}
+
+	// If in long mode, get all active todos
+	if opts.Mode == "long" {
+		// Reload to get the fresh state including the newly added todo
+		collection, err := s.Load()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load collection for long mode: %w", err)
+		}
+
+		result.AllTodos = collection.ListActive()
+		result.TotalCount, result.DoneCount = countTodos(collection.Todos)
+	}
+
+	return result, nil
+}
+
+// countTodos recursively counts total and done todos
+func countTodos(todos []*models.Todo) (total int, done int) {
+	for _, todo := range todos {
+		total++
+		if todo.Status == models.StatusDone {
+			done++
+		}
+		// Recursively count children
+		childTotal, childDone := countTodos(todo.Items)
+		total += childTotal
+		done += childDone
+	}
+	return total, done
 }

--- a/pkg/tdh/output/templates/add_result.tmpl
+++ b/pkg/tdh/output/templates/add_result.tmpl
@@ -1,1 +1,8 @@
+{{- if eq .Mode "long" -}}
 <success>Added todo</success> <position>#{{.Todo.Position}}</position>: {{.Todo.Text}}
+
+{{renderNestedTodosWithHighlight .AllTodos "" 0 .Todo.ID -}}
+<count>{{.TotalCount}} todo(s), {{.DoneCount}} done</count>
+{{- else -}}
+<success>Added todo</success> <position>#{{.Todo.Position}}</position>: {{.Todo.Text}}
+{{- end -}}

--- a/pkg/tdh/output/templates/complete_result.tmpl
+++ b/pkg/tdh/output/templates/complete_result.tmpl
@@ -1,1 +1,8 @@
+{{- if eq .Mode "long" -}}
 <success>✓</success> Completed: <value>{{.Todo.Text}}</value>
+
+{{renderNestedTodosWithHighlight .AllTodos "" 0 ""}}
+<count>{{.TotalCount}} todo(s), {{.DoneCount}} done</count>
+{{- else -}}
+<success>✓</success> Completed: <value>{{.Todo.Text}}</value>
+{{- end -}}


### PR DESCRIPTION
## Summary
- Add global `--mode` flag with values "short" (default) and "long"
- Short mode shows only the affected todo (preserves current behavior)
- Long mode shows the full active todo list with the affected todo highlighted
- Non-highlighted todos appear muted/fainter for visual distinction

## Implementation Details
- Added `--mode` persistent flag to root command with validation
- Updated command Options and Result structs to pass mode through the stack
- Created `renderNestedTodosWithHighlight` template function for highlighting
- Used Go template conditionals to handle both modes in same template files
- Applied Faint() style modifier to muted todos for better visual distinction

## Test plan
- [x] Manual testing of add command in both modes
- [x] Manual testing of complete command in both modes
- [x] Verified invalid mode values are rejected
- [x] Tested highlighting works correctly for newly added/modified todos
- [x] All existing tests pass
- [x] Pre-commit checks pass

## Example Usage
```bash
# Short mode (default) - shows only added todo
tdh add "New feature"

# Long mode - shows all todos with new one highlighted
tdh --mode long add "New feature"
tdh -m long add "New feature"  # short form

# Works with other commands too
tdh --mode long complete 1
```

The long mode is particularly useful when you want to see the context of your changes within the full todo list.

Fixes #115

🤖 Generated with [Claude Code](https://claude.ai/code)